### PR TITLE
PwdLastSet/MustChangePasswordAtNextLogon (&avoiding compile error)

### DIFF
--- a/src/main/java/com/evolveum/polygon/connector/ldap/ConnectionManager.java
+++ b/src/main/java/com/evolveum/polygon/connector/ldap/ConnectionManager.java
@@ -221,6 +221,11 @@ public class ConnectionManager<C extends AbstractLdapConfiguration> implements C
 					public LdapNetworkConnection next() {
 						return getConnection(serversIterator.next());
 					}
+
+					@Override
+					public void remove() {
+							serversIterator.remove();
+					}
 					
 				};
 			}


### PR DESCRIPTION
postUpdate handling for forcing "User must change password at next logon" in Active Directory
When pwdLastSet=0 in account, and a new password is set for this account 
pwdLastSet contains the timestamp of the password change. There is ia
strong mapping in midpoint to set pwdLastSet=0 but this does produce no modifications since mdpoint has seen pwdLastSet was already 0 before the update

This commit contains postUpdate handling to force pwdLastSet=0 when
password was changed.

Maybe there should some connector property to switch on/off this behaviour.
Additionally it would be possible to keep handling of pwdLastSet in connector on account creation.