### PR TITLE
Add FSP(Foreign Security Principal) processing for AD Connector

### DIFF
--- a/src/main/java/com/evolveum/polygon/connector/ldap/ad/AdLdapConfiguration.java
+++ b/src/main/java/com/evolveum/polygon/connector/ldap/ad/AdLdapConfiguration.java
@@ -151,6 +151,10 @@ public class AdLdapConfiguration extends AbstractLdapConfiguration {
      */
     private boolean forcePasswordChangeAtNextLogon = false;
 
+    /**
+     * If set to true then the connector will process FSP(Foreign Security Principal).
+     */
+    private boolean allowFSPProcessing = false;
 
     @ConfigurationProperty(order = 100)
     public String getUserObjectClass() {
@@ -267,6 +271,15 @@ public class AdLdapConfiguration extends AbstractLdapConfiguration {
 
     public void setForcePasswordChangeAtNextLogon(boolean forcePasswordChangeAtNextLogon) {
         this.forcePasswordChangeAtNextLogon = forcePasswordChangeAtNextLogon;
+    }
+
+    @ConfigurationProperty(order = 113)
+    public boolean isAllowFSPProcessing() {
+        return allowFSPProcessing;
+    }
+
+    public void setAllowFSPProcessing(boolean allowFSPProcessing) {
+        this.allowFSPProcessing = allowFSPProcessing;
     }
 
     @Override

--- a/src/main/java/com/evolveum/polygon/connector/ldap/ad/AdLdapConnector.java
+++ b/src/main/java/com/evolveum/polygon/connector/ldap/ad/AdLdapConnector.java
@@ -528,7 +528,7 @@ public class AdLdapConnector extends AbstractLdapConnector<AdLdapConfiguration> 
 
 
         // Trivial (but not really realistic) case: UID is DN
-
+        // Also, when the FSP object is first created, the UID is a DN, so it needs to be handled specially
         if (LdapUtil.isDnAttribute(getConfiguration().getUidAttribute()) || getSchemaTranslator().isFSPDn(uid.getUidValue())) {
 
             return searchByDn(getSchemaTranslator().toDn(uidValue), objectClass, ldapObjectClass, handler, options);

--- a/src/main/resources/com/evolveum/polygon/connector/ldap/Messages.properties
+++ b/src/main/resources/com/evolveum/polygon/connector/ldap/Messages.properties
@@ -230,3 +230,6 @@ addDefaultObjectCategory.help=If set to true then the connector will automatical
 
 forcePasswordChangeAtNextLogon.display=Force password change at next log-on
 forcePasswordChangeAtNextLogon.help=If set to true then the connector will force password change at next log-on every time when the password is changed. If set to false (default) the password change at next log-on will not be forced.
+
+allowFSPProcessing.display=Allow FSP processing
+allowFSPProcessing.help=If set to true then the connector will process FSP(Foreign Security Principal).

--- a/src/main/resources/com/evolveum/polygon/connector/ldap/ad/Messages.properties
+++ b/src/main/resources/com/evolveum/polygon/connector/ldap/ad/Messages.properties
@@ -226,6 +226,9 @@ addDefaultObjectCategory.help=If set to true then the connector will automatical
 forcePasswordChangeAtNextLogon.display=Force password change at next log-on
 forcePasswordChangeAtNextLogon.help=If set to true then the connector will force password change at next log-on every time when the password is changed. If set to false (default) the password change at next log-on will not be forced.
 
+allowFSPProcessing.display=Allow FSP processing
+allowFSPProcessing.help=If set to true then the connector will process FSP(Foreign Security Principal).
+
 # eDir
 
 manageReciprocalGroupAttributes.display=Manage reciprocal group attributes


### PR DESCRIPTION
## Motivation and Context

In the following Active Directory configuration, we'd like to provision group memberships across forests(domains).

- AD-A: `a.example.com`
- AD-B: `b.example.com`
- AD-A and AD-B have two-way forest trust

AD has a feature to handle this situation, it's called as ForeignSecurityPrincipal (FSP).

https://social.technet.microsoft.com/wiki/contents/articles/51367.active-directory-foreign-security-principals-and-special-identities.aspx 

In order to manage cross-forest group membership by FSP in midPoint, we need to create FocusObjects, ShadowObjects and AD side objects as shown in the figure below, for example.

![image](https://user-images.githubusercontent.com/28739/143531521-e9ccd262-698b-4c77-8163-ca2a576e9061.png)

The challenging part is that we cannot `ldapadd` the FSP object directly because of AD limitation; `ldapadd` will fail and the shadow will not be created. Instead, we need to add the FSP object to the group as a member in the format `<SID=$objectSid>` instead of DN.

Thus, special handling of FSP objects is required on this AD Connector side in order to manage group membership across forests.


## How Has This Been Tested?

I have built the following three ADs.

- AD-A: `a.example.com` / AD domain controller configured on Windows Server 2019
- AD-B: `b.example.com` / AD domain controller configured on Windows Server 2019
- AD-C: `c.example.com` / Built with AWS Managed Microsoft AD

Then I have configured the following two-way forest trust.

- `a.example.com` <-> `b.example.com`
- `a.example.com` <-> `c.example.com`

Then I tested the following cases.

- Create `b-test001` user on `b.example.com` and `a-org001` group on `a.example.com`, and add, update, and delete member of the group.
- Create `a-test001` user in `a.example.com` and `c-org001` group in `c.example.com`, and add, update, and delete member of the group.

Note: There is a caveat in Case 2. Due to the limitations of AWS Managed Microsoft AD, full administrative privileges are not available. In this case, there are the following restrictions:

- Cannot fetch `memberOf` of the FSP object
- FSP object cannot be deleted by `ldapdelete`

For this reason, the following settings must be needed in the resource definition of `c.example.com` in order to make case 2 work.

- `association`: Since memberOf cannot be referenced, the shortcut setting is not used.
- `existence`: Since it is not possible to delete FSP objects, set `existence` to prevent the deletion process from running.

The following is a part of the setting example.

```
            <association>
                <ref>ri:group</ref>
                <displayName>AD cross-forest group membership</displayName>
                <tolerant>false</tolerant>
                <kind>entitlement</kind>
                <intent>group</intent>
                <direction>objectToSubject</direction>
                <associationAttribute>ri:member</associationAttribute>
                <valueAttribute>ri:dn</valueAttribute>
                <!--
                    We can't use shortcut for AWS Managed Microsoft AD
                <shortcutAssociationAttribute>ri:memberOf</shortcutAssociationAttribute>
                <shortcutValueAttribute>ri:dn</shortcutValueAttribute>
                -->
                <explicitReferentialIntegrity>false</explicitReferentialIntegrity>
            </association>
            <activation>
                <existence>
                    <outbound>
                        <expression>
                            <script>
                                <code>
                                    // AWS Managed Microsoft AD cannot delete FSPs,
                                    // so suppress the deletion process
                                    true
                                </code>
                            </script>
                        </expression>
                    </outbound>
                </existence>
            </activation>
```