### PR TITLE
Att member values filter out

### DIFF
--- a/src/main/java/com/evolveum/polygon/connector/ldap/AbstractLdapConfiguration.java
+++ b/src/main/java/com/evolveum/polygon/connector/ldap/AbstractLdapConfiguration.java
@@ -517,7 +517,7 @@ public abstract class AbstractLdapConfiguration extends AbstractConfiguration {
     private boolean filterOutMemberOfValues = false;
 
     /**
-     * List of allowed value for memberOf attribute to be returned, only values ending with specified will be returned. If no value defined, all will be returned.
+     * List of allowed value for memberOf attribute to be returned, only values ending with specified will be returned. If no value defined, baseContext will be used.
      * This will be processed only when 'Filter memberOf' set to true
      */
     private String[] memberOfAllowedValues = { };

--- a/src/main/java/com/evolveum/polygon/connector/ldap/AbstractLdapConfiguration.java
+++ b/src/main/java/com/evolveum/polygon/connector/ldap/AbstractLdapConfiguration.java
@@ -509,6 +509,19 @@ public abstract class AbstractLdapConfiguration extends AbstractConfiguration {
      */
     private long switchBackInterval = DEFAULT_SWITCH_BACK_INTERVAL;
 
+    /**
+     * If set to true, connector will return only values of memberOf attribute that contains specified sequence.
+     * If set to false, no filtering will occur and all values will be returned.
+     * Default value: false
+     */
+    private boolean filterOutMemberOfValues = false;
+
+    /**
+     * List of allowed value for memberOf attribute to be returned. If no value defined, all will be returned.
+     * This will be processed only when 'Filter memberOf' set to true
+     */
+    private String[] memberOfAllowedValues = { };
+
     @ConfigurationProperty(required = true, order = 1)
     public String getHost() {
         return host;
@@ -1061,6 +1074,26 @@ public abstract class AbstractLdapConfiguration extends AbstractConfiguration {
     @SuppressWarnings("unused")
     public void setSwitchBackInterval(long switchBackInterval) {
         this.switchBackInterval = switchBackInterval;
+    }
+
+    @ConfigurationProperty(order = 57)
+    public boolean isFilterOutMemberOfValues() {
+        return filterOutMemberOfValues;
+    }
+
+    @SuppressWarnings("unused")
+    public void setFilterOutMemberOfValues(boolean filterOutMemberOfValues) {
+        this.filterOutMemberOfValues = filterOutMemberOfValues;
+    }
+
+    @ConfigurationProperty(order = 58)
+    public String[] getMemberOfAllowedValues() {
+        return memberOfAllowedValues;
+    }
+
+    @SuppressWarnings("unused")
+    public void setMemberOfAllowedValues(String[] memberOfAllowedValues) {
+        this.memberOfAllowedValues = memberOfAllowedValues;
     }
 
     @Override

--- a/src/main/java/com/evolveum/polygon/connector/ldap/AbstractLdapConfiguration.java
+++ b/src/main/java/com/evolveum/polygon/connector/ldap/AbstractLdapConfiguration.java
@@ -517,7 +517,7 @@ public abstract class AbstractLdapConfiguration extends AbstractConfiguration {
     private boolean filterOutMemberOfValues = false;
 
     /**
-     * List of allowed value for memberOf attribute to be returned. If no value defined, all will be returned.
+     * List of allowed value for memberOf attribute to be returned, only values ending with specified will be returned. If no value defined, all will be returned.
      * This will be processed only when 'Filter memberOf' set to true
      */
     private String[] memberOfAllowedValues = { };

--- a/src/main/java/com/evolveum/polygon/connector/ldap/schema/AbstractSchemaTranslator.java
+++ b/src/main/java/com/evolveum/polygon/connector/ldap/schema/AbstractSchemaTranslator.java
@@ -22,6 +22,7 @@ import java.security.NoSuchAlgorithmException;
 import java.text.ParseException;
 import java.time.ZonedDateTime;
 import java.util.*;
+import java.util.function.Predicate;
 
 import com.evolveum.polygon.connector.ldap.*;
 import com.evolveum.polygon.connector.ldap.connection.ConnectionManager;
@@ -1303,7 +1304,7 @@ public abstract class AbstractSchemaTranslator<C extends AbstractLdapConfigurati
 
     /**
      * Decide if value should be included in case filtering for memberOf attribute is set.
-     * All other attribtues and their value will not be checked for condition.
+     * All other attributes and their value will not be checked for condition matching.
      *
      * @param connIdValue {@link Object} value of attribute to be checked
      * @param ldapAttributeNameFromSchema {@link String} ldap attribute name to determine, if value should be checked
@@ -1315,11 +1316,16 @@ public abstract class AbstractSchemaTranslator<C extends AbstractLdapConfigurati
             String[] allowedValues = configuration.getMemberOfAllowedValues();
             if (configuration.isFilterOutMemberOfValues() && allowedValues != null && allowedValues.length > 0) {
                 if (connIdValue instanceof String) {
-                    LOG.ok("Processing memberOf attribute value {0}", connIdValue);
+                    //LOG.ok("Processing memberOf attribute value {0}", connIdValue);
                     String connIdValueString = (String) connIdValue;
-                    return Arrays.stream(allowedValues).anyMatch(allowedValue -> connIdValueString.regionMatches(true, connIdValueString.length() - allowedValue.length(), allowedValue, 0, allowedValue.length()));
-                } else {
-                    throw new InvalidAttributeValueException("Wrong value type for attribute "+ldapAttributeNameFromSchema+": "+connIdValue);
+                    return Arrays.stream(allowedValues)
+                                 .filter(Predicate.not(String::isEmpty))
+                                 .anyMatch(allowedValue -> connIdValueString.regionMatches(
+                                         true,
+                                         connIdValueString.length() - allowedValue.length(),
+                                         allowedValue,
+                                         0,
+                                         allowedValue.length()));
                 }
             }
         }

--- a/src/main/java/com/evolveum/polygon/connector/ldap/schema/AbstractSchemaTranslator.java
+++ b/src/main/java/com/evolveum/polygon/connector/ldap/schema/AbstractSchemaTranslator.java
@@ -21,14 +21,7 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.text.ParseException;
 import java.time.ZonedDateTime;
-import java.util.ArrayList;
-import java.util.Base64;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Random;
+import java.util.*;
 
 import com.evolveum.polygon.connector.ldap.*;
 import com.evolveum.polygon.connector.ldap.connection.ConnectionManager;
@@ -1288,7 +1281,7 @@ public abstract class AbstractSchemaTranslator<C extends AbstractLdapConfigurati
             Value ldapValue = iterator.next();
             Object connIdValue = toConnIdValue(connIdAttributeName, ldapValue, ldapAttributeNameFromSchema, ldapAttributeType);
             if (connIdValue != null) {
-                if (!incompleteRead) {
+                if (!incompleteRead && shouldValueBeIncluded(connIdValue, ldapAttributeNameFromSchema)) {
                     ab.addValue(connIdValue);
                 }
                 hasValidValue = true;
@@ -1306,6 +1299,31 @@ public abstract class AbstractSchemaTranslator<C extends AbstractLdapConfigurati
         } catch (IllegalArgumentException e) {
             throw new IllegalArgumentException(e.getMessage() + ", attribute "+connIdAttributeName+" (ldap: "+ldapAttributeNameFromSchema+")", e);
         }
+    }
+
+    /**
+     * Decide if value should be included in case filtering for memberOf attribute is set.
+     * All other attribtues and their value will not be checked for condition.
+     *
+     * @param connIdValue {@link Object} value of attribute to be checked
+     * @param ldapAttributeNameFromSchema {@link String} ldap attribute name to determine, if value should be checked
+     *
+     * @return Boolean true if value should be included, false in case value should be removed. Default: true
+     */
+    private boolean shouldValueBeIncluded(Object connIdValue, String ldapAttributeNameFromSchema) {
+        if (LdapConstants.ATTRIBUTE_MEMBER_OF_NAME.equalsIgnoreCase(ldapAttributeNameFromSchema)) {
+            String[] allowedValues = configuration.getMemberOfAllowedValues();
+            if (configuration.isFilterOutMemberOfValues() && allowedValues != null && allowedValues.length > 0) {
+                if (connIdValue instanceof String) {
+                    LOG.ok("Processing memberOf attribute value {0}", connIdValue);
+                    String connIdValueString = (String) connIdValue;
+                    return Arrays.stream(allowedValues).anyMatch(allowedValue -> connIdValueString.regionMatches(true, connIdValueString.length() - allowedValue.length(), allowedValue, 0, allowedValue.length()));
+                } else {
+                    throw new InvalidAttributeValueException("Wrong value type for attribute "+ldapAttributeNameFromSchema+": "+connIdValue);
+                }
+            }
+        }
+        return true;
     }
 
     protected Attribute toConnIdAttributePoly(String connIdAttributeName, String ldapAttributeNameFromSchema, AttributeType ldapAttributeType,

--- a/src/main/resources/com/evolveum/polygon/connector/ldap/Messages.properties
+++ b/src/main/resources/com/evolveum/polygon/connector/ldap/Messages.properties
@@ -176,10 +176,10 @@ switchBackInterval.display=Switch-back interval
 switchBackInterval.help=Interval (in milliseconds) for which the connector fails over to secondary server, in case the primary fails. The connector will use the secondary server during this interval. When the interval is over, the connector will try to use the primary server again.
 
 filterOutMemberOfValues.display=Filter memberOf
-filterOutMemberOfValues.help=If set to true, connector will return only values of memberOf attribute that contains specified sequence. If set to false, no filtering will occur and all values will be returned. Default value: false
+filterOutMemberOfValues.help=If set to true, connector will return only values of memberOf attribute that contains specified sequences from "MemberOf Allowed Suffixes". If set to false, no filtering will occur and all values will be returned. Default value: false
 
-memberOfAllowValues.display=MemberOf Allow
-memberOfAllowValues.help=List of allowed value for memberOf attribute to be returned. If no value defined, all will be returned. This will be processed only when 'Filter memberOf' set to true
+memberOfAllowedValues.display=MemberOf Allowed Suffixes
+memberOfAllowedValues.help=List of allowed value for memberOf attribute to be returned, only values ending with specified will be returned. If no value defined, all will be returned. This will be processed only when "Filter memberOf" set to true
 
 # LDAP
 

--- a/src/main/resources/com/evolveum/polygon/connector/ldap/Messages.properties
+++ b/src/main/resources/com/evolveum/polygon/connector/ldap/Messages.properties
@@ -179,7 +179,7 @@ filterOutMemberOfValues.display=Filter memberOf
 filterOutMemberOfValues.help=If set to true, connector will return only values of memberOf attribute that contains specified sequences from "MemberOf Allowed Suffixes". If set to false, no filtering will occur and all values will be returned. Default value: false
 
 memberOfAllowedValues.display=MemberOf Allowed Suffixes
-memberOfAllowedValues.help=List of allowed value for memberOf attribute to be returned, only values ending with specified will be returned. If no value defined, all will be returned. This will be processed only when "Filter memberOf" set to true
+memberOfAllowedValues.help=List of allowed value for memberOf attribute to be returned, only values ending with specified will be returned. If no value defined, "Base context" will be used for filtering. This will be processed only when "Filter memberOf" set to true
 
 # LDAP
 

--- a/src/main/resources/com/evolveum/polygon/connector/ldap/Messages.properties
+++ b/src/main/resources/com/evolveum/polygon/connector/ldap/Messages.properties
@@ -175,6 +175,11 @@ useUnbind.help=If set to true, then the connector will explicitly invoke LDAP un
 switchBackInterval.display=Switch-back interval
 switchBackInterval.help=Interval (in milliseconds) for which the connector fails over to secondary server, in case the primary fails. The connector will use the secondary server during this interval. When the interval is over, the connector will try to use the primary server again.
 
+filterOutMemberOfValues.display=Filter memberOf
+filterOutMemberOfValues.help=If set to true, connector will return only values of memberOf attribute that contains specified sequence. If set to false, no filtering will occur and all values will be returned. Default value: false
+
+memberOfAllowValues.display=MemberOf Allow
+memberOfAllowValues.help=List of allowed value for memberOf attribute to be returned. If no value defined, all will be returned. This will be processed only when 'Filter memberOf' set to true
 
 # LDAP
 

--- a/src/main/resources/com/evolveum/polygon/connector/ldap/ad/Messages.properties
+++ b/src/main/resources/com/evolveum/polygon/connector/ldap/ad/Messages.properties
@@ -170,7 +170,7 @@ filterOutMemberOfValues.display=Filter memberOf
 filterOutMemberOfValues.help=If set to true, connector will return only values of memberOf attribute that ends with specified sequences from "MemberOf Allowed Suffixes". If set to false, no filtering will occur and all values will be returned. Default value: false
 
 memberOfAllowedValues.display=MemberOf Allowed Suffixes
-memberOfAllowedValues.help=List of allowed value for memberOf attribute to be returned, only values ending with specified will be returned. If no value defined, all will be returned. This will be processed only when "Filter memberOf" set to true
+memberOfAllowedValues.help=List of allowed value for memberOf attribute to be returned, only values ending with specified will be returned. If no value defined, "Base context" will be used for filtering. This will be processed only when "Filter memberOf" set to true
 
 # LDAP
 

--- a/src/main/resources/com/evolveum/polygon/connector/ldap/ad/Messages.properties
+++ b/src/main/resources/com/evolveum/polygon/connector/ldap/ad/Messages.properties
@@ -166,6 +166,12 @@ structuralObjectClassesToAuxiliary.help=If set to true, adds all additional stru
 additionalSearchFilter.display=Additional search filter
 additionalSearchFilter.help=Search filter that will be added to all search operations that the connector does.
 
+filterOutMemberOfValues.display=Filter memberOf
+filterOutMemberOfValues.help=If set to true, connector will return only values of memberOf attribute that contains specified sequence. If set to false, no filtering will occur and all values will be returned. Default value: false
+
+memberOfAllowValues.display=MemberOf Allow
+memberOfAllowValues.help=List of allowed value for memberOf attribute to be returned. If no value defined, all will be returned. This will be processed only when 'Filter memberOf' set to true
+
 # LDAP
 
 lockoutStrategy.display=Lockout strategy

--- a/src/main/resources/com/evolveum/polygon/connector/ldap/ad/Messages.properties
+++ b/src/main/resources/com/evolveum/polygon/connector/ldap/ad/Messages.properties
@@ -167,10 +167,10 @@ additionalSearchFilter.display=Additional search filter
 additionalSearchFilter.help=Search filter that will be added to all search operations that the connector does.
 
 filterOutMemberOfValues.display=Filter memberOf
-filterOutMemberOfValues.help=If set to true, connector will return only values of memberOf attribute that contains specified sequence. If set to false, no filtering will occur and all values will be returned. Default value: false
+filterOutMemberOfValues.help=If set to true, connector will return only values of memberOf attribute that ends with specified sequences from "MemberOf Allowed Suffixes". If set to false, no filtering will occur and all values will be returned. Default value: false
 
-memberOfAllowValues.display=MemberOf Allow
-memberOfAllowValues.help=List of allowed value for memberOf attribute to be returned. If no value defined, all will be returned. This will be processed only when 'Filter memberOf' set to true
+memberOfAllowedValues.display=MemberOf Allowed Suffixes
+memberOfAllowedValues.help=List of allowed value for memberOf attribute to be returned, only values ending with specified will be returned. If no value defined, all will be returned. This will be processed only when "Filter memberOf" set to true
 
 # LDAP
 


### PR DESCRIPTION
Addition to processing of objects to LDAP/AD connector for filterring out some values of user's member (shortcut) attribute that could pointing out of vissible tree by baseContext configuration and reference an object not known to midPoint at that time.
Bring new configuration fields to set this, or could use a baseConext configuration as a default value to filter out any reference from outer tree space.