### PR TITLE
Added option to enable tree deletion for individual object classes

### DIFF
--- a/src/main/java/com/evolveum/polygon/connector/ldap/AbstractLdapConfiguration.java
+++ b/src/main/java/com/evolveum/polygon/connector/ldap/AbstractLdapConfiguration.java
@@ -352,6 +352,12 @@ public abstract class AbstractLdapConfiguration extends AbstractConfiguration {
     public static final String USE_TREE_DELETE_ALWAYS = "always";
 
     /**
+     * Enforces tree deletion for specified object classes.
+     * This overrides the useTreeDelete for the specified object classes.
+     */
+    private String[] forceTreeDeleteObjectClasses = { };
+
+    /**
      * Synchronization strategy to detect changes in real time.
      * Possible values: "none", "auto", ... TODO
      * Default value: auto
@@ -1096,6 +1102,16 @@ public abstract class AbstractLdapConfiguration extends AbstractConfiguration {
     @SuppressWarnings("unused")
     public void setMemberOfAllowedValues(String[] memberOfAllowedValues) {
         this.memberOfAllowedValues = memberOfAllowedValues;
+    }
+
+    @ConfigurationProperty(order = 59)
+    public String[] getForceTreeDeleteObjectClasses() {
+        return forceTreeDeleteObjectClasses;
+    }
+
+    @SuppressWarnings("unused")
+    public void setForceTreeDeleteObjectClasses(String[] forceTreeDeleteObjectClasses) {
+        this.forceTreeDeleteObjectClasses = forceTreeDeleteObjectClasses;
     }
 
     @Override

--- a/src/main/java/com/evolveum/polygon/connector/ldap/AbstractLdapConnector.java
+++ b/src/main/java/com/evolveum/polygon/connector/ldap/AbstractLdapConnector.java
@@ -474,7 +474,13 @@ public abstract class AbstractLdapConnector<C extends AbstractLdapConfiguration>
         return usePermissiveModify;
     }
 
-    protected boolean isUseTreeDelete() throws LdapException {
+    protected boolean isUseTreeDelete(ObjectClass objectClass) throws LdapException {
+        String[] forceObjClasses = configuration.getForceTreeDeleteObjectClasses();
+        for (String forceClass : forceObjClasses) {
+            if (objectClass.is(forceClass)) {
+                return true;
+            }
+        }
         if (useTreeDelete == null) {
             switch (configuration.getUseTreeDelete()) {
                 case AbstractLdapConfiguration.USE_TREE_DELETE_ALWAYS:
@@ -1492,7 +1498,7 @@ public abstract class AbstractLdapConnector<C extends AbstractLdapConfiguration>
             LOG.ok("Using (unsafe) DN from the name hint: {0}", dn);
             try {
 
-                deleteAttempt(dn, uid, options);
+                deleteAttempt(objectClass, dn, uid, options);
 
                 return;
 
@@ -1505,16 +1511,16 @@ public abstract class AbstractLdapConnector<C extends AbstractLdapConfiguration>
         dn = resolveDn(objectClass, uid, options);
         LOG.ok("Resolved DN: {0}", dn);
 
-        deleteAttempt(dn, uid, options);
+        deleteAttempt(objectClass, dn, uid, options);
     }
 
-    private void deleteAttempt(Dn dn, Uid uid, OperationOptions options) {
+    private void deleteAttempt(ObjectClass objectClass, Dn dn, Uid uid, OperationOptions options) {
 
         LdapNetworkConnection connection = connectionManager.getConnection(dn, options);
 
         try {
             Control treeDeleteControl = null;
-            if (isUseTreeDelete()) {
+            if (isUseTreeDelete(objectClass)) {
                 treeDeleteControl = new TreeDeleteImpl( );
             }
 

--- a/src/main/resources/com/evolveum/polygon/connector/ldap/Messages.properties
+++ b/src/main/resources/com/evolveum/polygon/connector/ldap/Messages.properties
@@ -181,6 +181,12 @@ filterOutMemberOfValues.help=If set to true, connector will return only values o
 memberOfAllowedValues.display=MemberOf Allowed Suffixes
 memberOfAllowedValues.help=List of allowed value for memberOf attribute to be returned, only values ending with specified will be returned. If no value defined, "Base context" will be used for filtering. This will be processed only when "Filter memberOf" set to true
 
+useTreeDelete.display=Use tree delete
+useTreeDelete.help=Usage of the LDAP tree deletion control. Possible values: "never", "auto" (if the tree delete control is supported), "always". Default value: never
+
+forceTreeDeleteObjectClasses.display=Force objectClass tree deletion
+forceTreeDeleteObjectClasses.help=Forces a tree deletion for specified objectClasses. This overrides the "Use tree delete" configuration for these objectClasses.
+
 # LDAP
 
 lockoutStrategy.display=Lockout strategy

--- a/src/main/resources/com/evolveum/polygon/connector/ldap/ad/Messages.properties
+++ b/src/main/resources/com/evolveum/polygon/connector/ldap/ad/Messages.properties
@@ -172,6 +172,12 @@ filterOutMemberOfValues.help=If set to true, connector will return only values o
 memberOfAllowedValues.display=MemberOf Allowed Suffixes
 memberOfAllowedValues.help=List of allowed value for memberOf attribute to be returned, only values ending with specified will be returned. If no value defined, "Base context" will be used for filtering. This will be processed only when "Filter memberOf" set to true
 
+useTreeDelete.display=Use tree delete
+useTreeDelete.help=Usage of the LDAP tree deletion control. Possible values: "never", "auto" (if the tree delete control is supported), "always". Default value: never
+
+forceTreeDeleteObjectClasses.display=Force objectClass tree deletion
+forceTreeDeleteObjectClasses.help=Forces a tree deletion for specified objectClasses. This overrides the "Use tree delete" configuration for these objectClasses.
+
 # LDAP
 
 lockoutStrategy.display=Lockout strategy


### PR DESCRIPTION
Previously the connector only offered the option for tree deletion for all objects in the LDAP.
Now you can use the tree deletion for configurable object classes (e.g. 'user') without enabling the feature for all object classes (which might be dangerous for 'organizationalUnit').