### PR TITLE
Allow to send the LDAP_DIRSYNC_OBJECT_SECURITY flag in Active Directory sync request control

### DIFF
--- a/src/main/java/com/evolveum/polygon/connector/ldap/ad/AdLdapConfiguration.java
+++ b/src/main/java/com/evolveum/polygon/connector/ldap/ad/AdLdapConfiguration.java
@@ -164,6 +164,11 @@ public class AdLdapConfiguration extends AbstractLdapConfiguration {
      */
     private boolean allowFSPProcessing = false;
 
+    /**
+     * If set to true set the flag security in the Active Directory Dir Sync control request.
+     */
+    private boolean sendDirSyncSecurityFlag;
+
     @ConfigurationProperty(order = 100)
     public String getUserObjectClass() {
         return userObjectClass;
@@ -297,6 +302,15 @@ public class AdLdapConfiguration extends AbstractLdapConfiguration {
 
     public void setAllowFSPProcessing(boolean allowFSPProcessing) {
         this.allowFSPProcessing = allowFSPProcessing;
+    }
+
+    @ConfigurationProperty(order = 115)
+    public boolean isSendDirSyncSecurityFlag() {
+        return sendDirSyncSecurityFlag;
+    }
+
+    public void setSendDirSyncSecurityFlag(boolean setDirSyncSecurityFlag) {
+        this.sendDirSyncSecurityFlag = setDirSyncSecurityFlag;
     }
 
     @Override

--- a/src/main/java/com/evolveum/polygon/connector/ldap/sync/AdDirSyncStrategy.java
+++ b/src/main/java/com/evolveum/polygon/connector/ldap/sync/AdDirSyncStrategy.java
@@ -48,6 +48,7 @@ import org.identityconnectors.framework.common.objects.Uid;
 import org.identityconnectors.framework.spi.SyncTokenResultsHandler;
 
 import com.evolveum.polygon.connector.ldap.ad.AdConstants;
+import com.evolveum.polygon.connector.ldap.ad.AdLdapConfiguration;
 import com.evolveum.polygon.connector.ldap.schema.AbstractSchemaTranslator;
 
 /**
@@ -272,6 +273,12 @@ public class AdDirSyncStrategy<C extends AbstractLdapConfiguration> extends Sync
 
         AdDirSyncRequestImpl dirSyncReqControl = new AdDirSyncRequestImpl();
         dirSyncReqControl.setCritical(true);
+        if (((AdLdapConfiguration)getConfiguration()).isSendDirSyncSecurityFlag()) {
+            // See https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-adts/2213a7f2-0a36-483c-b2a4-8574d53aa1e3?redirectedfrom=MSDN
+            // or https://docs.ldap.com/ldap-sdk/docs/javadoc/com/unboundid/ldap/sdk/experimental/ActiveDirectoryDirSyncControl.html
+            // Note : in the Apache LDAP DSK the definition of the first control attribute is named "parentsFirst" instead of "flags"
+            dirSyncReqControl.setParentsFirst(0x0000_0001);
+        }
         byte[] cookie = null;
         if (fromToken != null) {
             Object tokenValue = fromToken.getValue();

--- a/src/main/resources/com/evolveum/polygon/connector/ldap/ad/Messages.properties
+++ b/src/main/resources/com/evolveum/polygon/connector/ldap/ad/Messages.properties
@@ -254,6 +254,9 @@ forcePasswordChangeAtNextLogon.help=If set to true then the connector will force
 allowFSPProcessing.display=Allow FSP processing
 allowFSPProcessing.help=If set to true then the connector will process FSP(Foreign Security Principal).
 
+sendDirSyncSecurityFlag.display=Send LDAP_DIRSYNC_OBJECT_SECURITY flag
+sendDirSyncSecurityFlag.help=If set to true, send the flag LDAP_DIRSYNC_OBJECT_SECURITY in the request control for the Active Directory sync request.
+
 # eDir
 
 manageReciprocalGroupAttributes.display=Manage reciprocal group attributes


### PR DESCRIPTION
Pull request for https://support.evolveum.com/projects/midpoint/work_packages/9795/activity.