### PR TITLE
feat: Update SunChangelogSyncStrategy to be configurable (and hence generic)

### DIFF
--- a/src/main/java/com/evolveum/polygon/connector/ldap/AbstractLdapConfiguration.java
+++ b/src/main/java/com/evolveum/polygon/connector/ldap/AbstractLdapConfiguration.java
@@ -464,6 +464,13 @@ public abstract class AbstractLdapConfiguration extends AbstractConfiguration {
      * Default value from original SunChangelogSyncStrategy for backwards-compatibility
      */
     private String changeLogTargetDNAttribute = "targetDN";
+
+    /**
+     * List of attributes to filter out from the changes LDIF in a changelog entry
+     * Needed for directories such as Isode M-Vault which includes "dn" and "changeType"
+     * attributes for "add" operations within the changes LDIF.
+     */
+    private String[] changeLogFilteredAttributes = { };
     
     /**
      * Entry DN can be provided to the connector as a "name hint". Connector will use the name hint whenever
@@ -1148,8 +1155,17 @@ public abstract class AbstractLdapConfiguration extends AbstractConfiguration {
     public void setChangeLogTargetDNAttribute(String changeLogTargetDNAttribute) {
     	this.changeLogTargetDNAttribute = changeLogTargetDNAttribute;
     }
-    
+
     @ConfigurationProperty(order = 52)
+    public String[] getChangeLogFilteredAttributes() {
+        return changeLogFilteredAttributes;
+    }
+
+    public void setChangeLogFilteredAttributes(String[] changeLogFilteredAttributes) {
+        this.changeLogFilteredAttributes = changeLogFilteredAttributes;
+    }
+    
+    @ConfigurationProperty(order = 53)
     public boolean isUseUnsafeNameHint() {
         return useUnsafeNameHint;
     }
@@ -1159,7 +1175,7 @@ public abstract class AbstractLdapConfiguration extends AbstractConfiguration {
         this.useUnsafeNameHint = useUnsafeNameHint;
     }
 
-    @ConfigurationProperty(order = 53, allowedValues = { TEST_MODE_FULL, TEST_MODE_ANY, TEST_MODE_PRIMARY })
+    @ConfigurationProperty(order = 54, allowedValues = { TEST_MODE_FULL, TEST_MODE_ANY, TEST_MODE_PRIMARY })
     public String getTestMode() {
         return testMode;
     }
@@ -1169,7 +1185,7 @@ public abstract class AbstractLdapConfiguration extends AbstractConfiguration {
         this.testMode = testMode;
     }
 
-    @ConfigurationProperty(order = 54)
+    @ConfigurationProperty(order = 55)
     public boolean isEnableExtraTests() {
         return enableExtraTests;
     }
@@ -1179,7 +1195,7 @@ public abstract class AbstractLdapConfiguration extends AbstractConfiguration {
         this.enableExtraTests = enableExtraTests;
     }
 
-    @ConfigurationProperty(order = 55, allowedValues = { TIMESTAMP_PRESENTATION_NATIVE, TIMESTAMP_PRESENTATION_STRING, TIMESTAMP_PRESENTATION_UNIX_EPOCH })
+    @ConfigurationProperty(order = 56, allowedValues = { TIMESTAMP_PRESENTATION_NATIVE, TIMESTAMP_PRESENTATION_STRING, TIMESTAMP_PRESENTATION_UNIX_EPOCH })
     public String getTimestampPresentation() {
         return timestampPresentation;
     }
@@ -1189,7 +1205,7 @@ public abstract class AbstractLdapConfiguration extends AbstractConfiguration {
         this.timestampPresentation = timestampPresentation;
     }
 
-    @ConfigurationProperty(order = 56)
+    @ConfigurationProperty(order = 57)
     public boolean isIncludeObjectClassFilter() {
         return includeObjectClassFilter;
     }
@@ -1199,7 +1215,7 @@ public abstract class AbstractLdapConfiguration extends AbstractConfiguration {
         this.includeObjectClassFilter = includeObjectClassFilter;
     }
 
-    @ConfigurationProperty(order = 57)
+    @ConfigurationProperty(order = 58)
     public boolean isAlternativeObjectClassDetection() {
         return alternativeObjectClassDetection;
     }
@@ -1209,7 +1225,7 @@ public abstract class AbstractLdapConfiguration extends AbstractConfiguration {
         this.alternativeObjectClassDetection = alternativeObjectClassDetection;
     }
 
-    @ConfigurationProperty(order = 58)
+    @ConfigurationProperty(order = 59)
     public boolean isStructuralObjectClassesToAuxiliary() {
         return structuralObjectClassesToAuxiliary;
     }
@@ -1219,7 +1235,7 @@ public abstract class AbstractLdapConfiguration extends AbstractConfiguration {
         this.structuralObjectClassesToAuxiliary = structuralObjectClassesToAuxiliary;
     }
 
-    @ConfigurationProperty(order = 59, allowedValues = { RUN_AS_STRATEGY_NONE, RUN_AS_STRATEGY_BIND })
+    @ConfigurationProperty(order = 60, allowedValues = { RUN_AS_STRATEGY_NONE, RUN_AS_STRATEGY_BIND })
     public String getRunAsStrategy() {
         return runAsStrategy;
     }
@@ -1229,7 +1245,7 @@ public abstract class AbstractLdapConfiguration extends AbstractConfiguration {
         this.runAsStrategy = runAsStrategy;
     }
 
-    @ConfigurationProperty(order = 60)
+    @ConfigurationProperty(order = 61)
     public String getAdditionalSearchFilter() {
         return additionalSearchFilter;
     }
@@ -1239,7 +1255,7 @@ public abstract class AbstractLdapConfiguration extends AbstractConfiguration {
         this.additionalSearchFilter = additionalSearchFilter;
     }
 
-    @ConfigurationProperty(order = 61, allowedValues = { SEARCH_SCOPE_SUB, SEARCH_SCOPE_ONE })
+    @ConfigurationProperty(order = 62, allowedValues = { SEARCH_SCOPE_SUB, SEARCH_SCOPE_ONE })
     public String getDefaultSearchScope() {
         return defaultSearchScope;
     }
@@ -1249,7 +1265,7 @@ public abstract class AbstractLdapConfiguration extends AbstractConfiguration {
         this.defaultSearchScope = searchScope;
     }
 
-    @ConfigurationProperty(order = 62)
+    @ConfigurationProperty(order = 63)
     public boolean isAllowUntrustedSsl() {
         return allowUntrustedSsl;
     }
@@ -1259,7 +1275,7 @@ public abstract class AbstractLdapConfiguration extends AbstractConfiguration {
         this.allowUntrustedSsl = allowUntrustedSsl;
     }
 
-    @ConfigurationProperty(order = 63)
+    @ConfigurationProperty(order = 64)
     public boolean isUseUnbind() {
         return useUnbind;
     }
@@ -1269,7 +1285,7 @@ public abstract class AbstractLdapConfiguration extends AbstractConfiguration {
         this.useUnbind = useUnbind;
     }
 
-    @ConfigurationProperty(order = 64)
+    @ConfigurationProperty(order = 65)
     public long getSwitchBackInterval() {
         return switchBackInterval;
     }
@@ -1279,7 +1295,7 @@ public abstract class AbstractLdapConfiguration extends AbstractConfiguration {
         this.switchBackInterval = switchBackInterval;
     }
 
-    @ConfigurationProperty(order = 65)
+    @ConfigurationProperty(order = 66)
     public boolean isFilterOutMemberOfValues() {
         return filterOutMemberOfValues;
     }
@@ -1289,7 +1305,7 @@ public abstract class AbstractLdapConfiguration extends AbstractConfiguration {
         this.filterOutMemberOfValues = filterOutMemberOfValues;
     }
 
-    @ConfigurationProperty(order = 66)
+    @ConfigurationProperty(order = 67)
     public String[] getMemberOfAllowedValues() {
         return memberOfAllowedValues;
     }
@@ -1299,7 +1315,7 @@ public abstract class AbstractLdapConfiguration extends AbstractConfiguration {
         this.memberOfAllowedValues = memberOfAllowedValues;
     }
 
-    @ConfigurationProperty(order = 67)
+    @ConfigurationProperty(order = 68)
     public String[] getForceTreeDeleteObjectClasses() {
         return forceTreeDeleteObjectClasses;
     }
@@ -1310,8 +1326,7 @@ public abstract class AbstractLdapConfiguration extends AbstractConfiguration {
 
     }
 
-    @ConfigurationProperty(order = 68)
-
+    @ConfigurationProperty(order = 69)
     public String[] getGroupObjectClasses() {
         return groupObjectClasses;
     }
@@ -1320,7 +1335,7 @@ public abstract class AbstractLdapConfiguration extends AbstractConfiguration {
         this.groupObjectClasses = groupObjectClasses;
     }
 
-    @ConfigurationProperty(order = 69)
+    @ConfigurationProperty(order = 70)
     public String[] getManagedAssociationPairs() {
         return managedAssociationPairs;
     }
@@ -1329,7 +1344,7 @@ public abstract class AbstractLdapConfiguration extends AbstractConfiguration {
         this.managedAssociationPairs = managedAssociationPairs;
     }
 
-    @ConfigurationProperty(order = 70)
+    @ConfigurationProperty(order = 71)
     public boolean getEncodeStringOnNormalizationFailure() {
         return encodeStringOnNormalizationFailure;
     }
@@ -1338,7 +1353,7 @@ public abstract class AbstractLdapConfiguration extends AbstractConfiguration {
         this.encodeStringOnNormalizationFailure = encodeStringOnNormalizationFailure;
     }
 
-    @ConfigurationProperty(order = 71)
+    @ConfigurationProperty(order = 72)
     public String[] getAttributesNotReturnedByDefault() {
         return attributesNotReturnedByDefault;
     }
@@ -1347,7 +1362,7 @@ public abstract class AbstractLdapConfiguration extends AbstractConfiguration {
         this.attributesNotReturnedByDefault = attributesNotReturnedByDefault;
     }
 
-    @ConfigurationProperty(order = 72)
+    @ConfigurationProperty(order = 73)
     public String[] getAuxiliaryObjectClasses() {
         return auxiliaryObjectClasses;
     }
@@ -1356,7 +1371,7 @@ public abstract class AbstractLdapConfiguration extends AbstractConfiguration {
         this.auxiliaryObjectClasses = auxiliaryObjectClasses;
     }
 
-    @ConfigurationProperty(order = 73)
+    @ConfigurationProperty(order = 74)
     public String getLastLoginDateAttribute() {
         return lastLoginDateAttribute;
     }
@@ -1365,7 +1380,7 @@ public abstract class AbstractLdapConfiguration extends AbstractConfiguration {
         this.lastLoginDateAttribute = lastLoginDateAttribute;
     }
 
-    @ConfigurationProperty(order = 74)
+    @ConfigurationProperty(order = 75)
     public boolean isLogSchemaErrors() {
         return logSchemaErrors;
     }

--- a/src/main/java/com/evolveum/polygon/connector/ldap/AbstractLdapConfiguration.java
+++ b/src/main/java/com/evolveum/polygon/connector/ldap/AbstractLdapConfiguration.java
@@ -372,6 +372,7 @@ public abstract class AbstractLdapConfiguration extends AbstractConfiguration {
 
     public static final String SYNCHRONIZATION_STRATEGY_NONE = "none";
     public static final String SYNCHRONIZATION_STRATEGY_AUTO = "auto";
+    public static final String SYNCHRONIZATION_STRATEGY_GENERIC_CHANGE_LOG = "genericChangeLog";
     public static final String SYNCHRONIZATION_STRATEGY_SUN_CHANGE_LOG = "sunChangeLog";
     public static final String SYNCHRONIZATION_STRATEGY_MODIFY_TIMESTAMP = "modifyTimestamp";
     public static final String SYNCHRONIZATION_STRATEGY_OPEN_LDAP_ACCESSLOG = "openLdapAccessLog";
@@ -410,6 +411,53 @@ public abstract class AbstractLdapConfiguration extends AbstractConfiguration {
      */
     private String changeNumberAttribute = "changeNumber";
 
+    /**
+     * Attribute name on the RootDSE entry containing the changelog DN
+     * Default value from original SunChangelogSyncStrategy for backwards-compatibility 
+     */
+    private String changeLogRootDSEAttribute = CHANGELOG_SUNDS_CHANGE_LOG_ROOT_DSE_ATTRIBUTE;
+    
+    public static final String CHANGELOG_SUNDS_CHANGE_LOG_ROOT_DSE_ATTRIBUTE = "changelog";
+    
+    /**
+     * DN of the changelog where it cannot be determined from the RootDSE
+     */
+    private String changeLogDN = CHANGELOG_DEFAULT_CHANGE_LOG_DN;
+    
+    public static final String CHANGELOG_DEFAULT_CHANGE_LOG_DN = "cn=changelog";
+    
+    /**
+     * Name of the attribute on the changelog entry containing the lowest change number of an entry
+     * within the changelog
+     * Default value from original SunChangelogSyncStrategy for backwards-compatibility 
+     */
+    private String changeLogFirstChangeNumberAttribute = "firstChangeNumber";
+    
+    /**
+     * Name of the attribute on the changelog entry containing the highest change number of an entry
+     * within the changelog
+     * Default value from original SunChangelogSyncStrategy for backwards-compatibility
+     */
+    private String changeLogLastChangeNumberAttribute = "lastChangeNumber";
+    
+    /**
+     * Name of the attribute containing the unique identifier of the modified object in the changelog
+     * Default value from original SunChangelogSyncStrategy for backwards-compatibility
+     */
+    private String changeLogTargetUniqueIdAttribute = "targetUniqueID";
+    
+    /**
+     * Name of the attribute containing the entryUUID of the modified object in the changelog
+     * Default value from original SunChangelogSyncStrategy for backwards-compatibility
+     */
+    private String changeLogTargetEntryUUIDAttribute = "targetEntryUUID";
+    
+    /**
+     * Name of the attribute containing the target DN of the modified object in the changelog
+     * Default value from original SunChangelogSyncStrategy for backwards-compatibility
+     */
+    private String changeLogTargetDNAttribute = "targetDN";
+    
     /**
      * Entry DN can be provided to the connector as a "name hint". Connector will use the name hint whenever
      * it can use it safely. But there are some cases when the name hint cannot be used safely. There are
@@ -945,7 +993,7 @@ public abstract class AbstractLdapConfiguration extends AbstractConfiguration {
         this.useTreeDelete = useTreeDelete;
     }
 
-    @ConfigurationProperty(order = 37, allowedValues = { SYNCHRONIZATION_STRATEGY_NONE, SYNCHRONIZATION_STRATEGY_AUTO, SYNCHRONIZATION_STRATEGY_SUN_CHANGE_LOG, SYNCHRONIZATION_STRATEGY_OPEN_LDAP_ACCESSLOG, SYNCHRONIZATION_STRATEGY_MODIFY_TIMESTAMP, SYNCHRONIZATION_STRATEGY_AD_DIR_SYNC })
+    @ConfigurationProperty(order = 37, allowedValues = { SYNCHRONIZATION_STRATEGY_NONE, SYNCHRONIZATION_STRATEGY_AUTO, SYNCHRONIZATION_STRATEGY_GENERIC_CHANGE_LOG, SYNCHRONIZATION_STRATEGY_SUN_CHANGE_LOG, SYNCHRONIZATION_STRATEGY_OPEN_LDAP_ACCESSLOG, SYNCHRONIZATION_STRATEGY_MODIFY_TIMESTAMP, SYNCHRONIZATION_STRATEGY_AD_DIR_SYNC })
     public String getSynchronizationStrategy() {
         return synchronizationStrategy;
     }
@@ -1015,6 +1063,76 @@ public abstract class AbstractLdapConfiguration extends AbstractConfiguration {
     }
 
     @ConfigurationProperty(order = 44)
+    public String getChangeLogRootDSEAttribute() {
+    	return changeLogRootDSEAttribute;
+    }
+    
+    @SuppressWarnings("unused")
+    public void setChangeLogRootDSEAttribute(String changeLogRootDSEAttribute) {
+    	this.changeLogRootDSEAttribute = changeLogRootDSEAttribute;
+    } 
+
+    @ConfigurationProperty(order = 45)
+    public String getChangeLogDN() {
+    	return changeLogDN;
+    }
+    
+    @SuppressWarnings("unused")
+    public void setChangeLogDN(String changeLogDN) {
+    	this.changeLogDN = changeLogDN;
+    }
+    
+    @ConfigurationProperty(order = 46)
+    public String getChangeLogFirstChangeNumberAttribute() {
+    	return changeLogFirstChangeNumberAttribute;
+    }
+    
+    @SuppressWarnings("unused")
+    public void setChangeLogFirstChangeNumberAttribute(String changeLogFirstChangeNumberAttribute) {
+    	this.changeLogFirstChangeNumberAttribute = changeLogFirstChangeNumberAttribute;
+    }
+    
+    @ConfigurationProperty(order = 47)
+    public String getChangeLogLastChangeNumberAttribute() {
+    	return changeLogLastChangeNumberAttribute;
+    }
+    
+    @SuppressWarnings("unused")
+    public void setChangeLogLastChangeNumberAttribute(String changeLogLastChangeNumberAttribute) {
+    	this.changeLogLastChangeNumberAttribute = changeLogLastChangeNumberAttribute;
+    }
+    
+    @ConfigurationProperty(order = 48)
+    public String getChangeLogTargetUniqueIdAttribute() {
+    	return changeLogTargetUniqueIdAttribute;
+    }
+    
+    @SuppressWarnings("unused")
+    public void setChangeLogTargetUniqueIdAttribute(String changeLogTargetUniqueIdAttribute) {
+    	this.changeLogTargetUniqueIdAttribute = changeLogTargetUniqueIdAttribute;
+    }
+    
+    @ConfigurationProperty(order = 49)
+    public String getChangeLogTargetEntryUUIDAttribute() {
+    	return changeLogTargetEntryUUIDAttribute;
+    }
+    
+    @SuppressWarnings("unused")
+    public void setChangeLogTargetEntryUUIDAttribute(String changeLogTargetEntryUUIDAttribute) {
+    	this.changeLogTargetEntryUUIDAttribute = changeLogTargetEntryUUIDAttribute;
+    }
+    
+    @ConfigurationProperty(order = 50)
+    public String getChangeLogTargetDNAttribute() {
+    	return changeLogTargetDNAttribute;
+    }
+    
+    @SuppressWarnings("unused")
+    public void setChangeLogTargetDNAttribute(String changeLogTargetDNAttribute) {
+    	this.changeLogTargetDNAttribute = changeLogTargetDNAttribute;
+    }
+    
+    @ConfigurationProperty(order = 51)
     public boolean isUseUnsafeNameHint() {
         return useUnsafeNameHint;
     }
@@ -1024,7 +1142,7 @@ public abstract class AbstractLdapConfiguration extends AbstractConfiguration {
         this.useUnsafeNameHint = useUnsafeNameHint;
     }
 
-    @ConfigurationProperty(order = 45, allowedValues = { TEST_MODE_FULL, TEST_MODE_ANY, TEST_MODE_PRIMARY })
+    @ConfigurationProperty(order = 52, allowedValues = { TEST_MODE_FULL, TEST_MODE_ANY, TEST_MODE_PRIMARY })
     public String getTestMode() {
         return testMode;
     }
@@ -1034,7 +1152,7 @@ public abstract class AbstractLdapConfiguration extends AbstractConfiguration {
         this.testMode = testMode;
     }
 
-    @ConfigurationProperty(order = 46)
+    @ConfigurationProperty(order = 53)
     public boolean isEnableExtraTests() {
         return enableExtraTests;
     }
@@ -1044,7 +1162,7 @@ public abstract class AbstractLdapConfiguration extends AbstractConfiguration {
         this.enableExtraTests = enableExtraTests;
     }
 
-    @ConfigurationProperty(order = 47, allowedValues = { TIMESTAMP_PRESENTATION_NATIVE, TIMESTAMP_PRESENTATION_STRING, TIMESTAMP_PRESENTATION_UNIX_EPOCH })
+    @ConfigurationProperty(order = 54, allowedValues = { TIMESTAMP_PRESENTATION_NATIVE, TIMESTAMP_PRESENTATION_STRING, TIMESTAMP_PRESENTATION_UNIX_EPOCH })
     public String getTimestampPresentation() {
         return timestampPresentation;
     }
@@ -1054,7 +1172,7 @@ public abstract class AbstractLdapConfiguration extends AbstractConfiguration {
         this.timestampPresentation = timestampPresentation;
     }
 
-    @ConfigurationProperty(order = 48)
+    @ConfigurationProperty(order = 55)
     public boolean isIncludeObjectClassFilter() {
         return includeObjectClassFilter;
     }
@@ -1064,7 +1182,7 @@ public abstract class AbstractLdapConfiguration extends AbstractConfiguration {
         this.includeObjectClassFilter = includeObjectClassFilter;
     }
 
-    @ConfigurationProperty(order = 49)
+    @ConfigurationProperty(order = 56)
     public boolean isAlternativeObjectClassDetection() {
         return alternativeObjectClassDetection;
     }
@@ -1074,7 +1192,7 @@ public abstract class AbstractLdapConfiguration extends AbstractConfiguration {
         this.alternativeObjectClassDetection = alternativeObjectClassDetection;
     }
 
-    @ConfigurationProperty(order = 50)
+    @ConfigurationProperty(order = 57)
     public boolean isStructuralObjectClassesToAuxiliary() {
         return structuralObjectClassesToAuxiliary;
     }
@@ -1084,7 +1202,7 @@ public abstract class AbstractLdapConfiguration extends AbstractConfiguration {
         this.structuralObjectClassesToAuxiliary = structuralObjectClassesToAuxiliary;
     }
 
-    @ConfigurationProperty(order = 51, allowedValues = { RUN_AS_STRATEGY_NONE, RUN_AS_STRATEGY_BIND })
+    @ConfigurationProperty(order = 58, allowedValues = { RUN_AS_STRATEGY_NONE, RUN_AS_STRATEGY_BIND })
     public String getRunAsStrategy() {
         return runAsStrategy;
     }
@@ -1094,7 +1212,7 @@ public abstract class AbstractLdapConfiguration extends AbstractConfiguration {
         this.runAsStrategy = runAsStrategy;
     }
 
-    @ConfigurationProperty(order = 52)
+    @ConfigurationProperty(order = 59)
     public String getAdditionalSearchFilter() {
         return additionalSearchFilter;
     }
@@ -1104,7 +1222,7 @@ public abstract class AbstractLdapConfiguration extends AbstractConfiguration {
         this.additionalSearchFilter = additionalSearchFilter;
     }
 
-    @ConfigurationProperty(order = 53, allowedValues = { SEARCH_SCOPE_SUB, SEARCH_SCOPE_ONE })
+    @ConfigurationProperty(order = 60, allowedValues = { SEARCH_SCOPE_SUB, SEARCH_SCOPE_ONE })
     public String getDefaultSearchScope() {
         return defaultSearchScope;
     }
@@ -1114,7 +1232,7 @@ public abstract class AbstractLdapConfiguration extends AbstractConfiguration {
         this.defaultSearchScope = searchScope;
     }
 
-    @ConfigurationProperty(order = 54)
+    @ConfigurationProperty(order = 61)
     public boolean isAllowUntrustedSsl() {
         return allowUntrustedSsl;
     }
@@ -1124,7 +1242,7 @@ public abstract class AbstractLdapConfiguration extends AbstractConfiguration {
         this.allowUntrustedSsl = allowUntrustedSsl;
     }
 
-    @ConfigurationProperty(order = 55)
+    @ConfigurationProperty(order = 62)
     public boolean isUseUnbind() {
         return useUnbind;
     }
@@ -1134,7 +1252,7 @@ public abstract class AbstractLdapConfiguration extends AbstractConfiguration {
         this.useUnbind = useUnbind;
     }
 
-    @ConfigurationProperty(order = 56)
+    @ConfigurationProperty(order = 63)
     public long getSwitchBackInterval() {
         return switchBackInterval;
     }
@@ -1144,7 +1262,7 @@ public abstract class AbstractLdapConfiguration extends AbstractConfiguration {
         this.switchBackInterval = switchBackInterval;
     }
 
-    @ConfigurationProperty(order = 57)
+    @ConfigurationProperty(order = 64)
     public boolean isFilterOutMemberOfValues() {
         return filterOutMemberOfValues;
     }
@@ -1154,7 +1272,7 @@ public abstract class AbstractLdapConfiguration extends AbstractConfiguration {
         this.filterOutMemberOfValues = filterOutMemberOfValues;
     }
 
-    @ConfigurationProperty(order = 58)
+    @ConfigurationProperty(order = 65)
     public String[] getMemberOfAllowedValues() {
         return memberOfAllowedValues;
     }
@@ -1164,7 +1282,7 @@ public abstract class AbstractLdapConfiguration extends AbstractConfiguration {
         this.memberOfAllowedValues = memberOfAllowedValues;
     }
 
-    @ConfigurationProperty(order = 59)
+    @ConfigurationProperty(order = 66)
     public String[] getForceTreeDeleteObjectClasses() {
         return forceTreeDeleteObjectClasses;
     }
@@ -1175,7 +1293,7 @@ public abstract class AbstractLdapConfiguration extends AbstractConfiguration {
 
     }
 
-    @ConfigurationProperty(order = 60)
+    @ConfigurationProperty(order = 67)
 
     public String[] getGroupObjectClasses() {
         return groupObjectClasses;
@@ -1185,7 +1303,7 @@ public abstract class AbstractLdapConfiguration extends AbstractConfiguration {
         this.groupObjectClasses = groupObjectClasses;
     }
 
-    @ConfigurationProperty(order = 61)
+    @ConfigurationProperty(order = 68)
     public String[] getManagedAssociationPairs() {
         return managedAssociationPairs;
     }
@@ -1194,7 +1312,7 @@ public abstract class AbstractLdapConfiguration extends AbstractConfiguration {
         this.managedAssociationPairs = managedAssociationPairs;
     }
 
-    @ConfigurationProperty(order = 62)
+    @ConfigurationProperty(order = 69)
     public boolean getEncodeStringOnNormalizationFailure() {
         return encodeStringOnNormalizationFailure;
     }
@@ -1203,7 +1321,7 @@ public abstract class AbstractLdapConfiguration extends AbstractConfiguration {
         this.encodeStringOnNormalizationFailure = encodeStringOnNormalizationFailure;
     }
 
-    @ConfigurationProperty(order = 63)
+    @ConfigurationProperty(order = 70)
     public String[] getAttributesNotReturnedByDefault() {
         return attributesNotReturnedByDefault;
     }
@@ -1212,7 +1330,7 @@ public abstract class AbstractLdapConfiguration extends AbstractConfiguration {
         this.attributesNotReturnedByDefault = attributesNotReturnedByDefault;
     }
 
-    @ConfigurationProperty(order = 63)
+    @ConfigurationProperty(order = 71)
     public String[] getAuxiliaryObjectClasses() {
         return auxiliaryObjectClasses;
     }
@@ -1221,7 +1339,7 @@ public abstract class AbstractLdapConfiguration extends AbstractConfiguration {
         this.auxiliaryObjectClasses = auxiliaryObjectClasses;
     }
 
-    @ConfigurationProperty(order = 64)
+    @ConfigurationProperty(order = 72)
     public String getLastLoginDateAttribute() {
         return lastLoginDateAttribute;
     }
@@ -1230,7 +1348,7 @@ public abstract class AbstractLdapConfiguration extends AbstractConfiguration {
         this.lastLoginDateAttribute = lastLoginDateAttribute;
     }
 
-    @ConfigurationProperty(order = 65)
+    @ConfigurationProperty(order = 73)
     public boolean isLogSchemaErrors() {
         return logSchemaErrors;
     }

--- a/src/main/java/com/evolveum/polygon/connector/ldap/AbstractLdapConfiguration.java
+++ b/src/main/java/com/evolveum/polygon/connector/ldap/AbstractLdapConfiguration.java
@@ -441,6 +441,13 @@ public abstract class AbstractLdapConfiguration extends AbstractConfiguration {
     private String changeLogLastChangeNumberAttribute = "lastChangeNumber";
     
     /**
+     * Whether the configured first and last change number attributes are found on the root DSE
+     * or on the changelog entry as configured by changeLogDN
+     * Default value for backwards-compatibility with SunChangelogSyncStrategy is true.
+     */
+    private Boolean changeLogChangeNumberAttributesOnRootDSE = true;
+
+    /**
      * Name of the attribute containing the unique identifier of the modified object in the changelog
      * Default value from original SunChangelogSyncStrategy for backwards-compatibility
      */
@@ -1101,8 +1108,18 @@ public abstract class AbstractLdapConfiguration extends AbstractConfiguration {
     public void setChangeLogLastChangeNumberAttribute(String changeLogLastChangeNumberAttribute) {
     	this.changeLogLastChangeNumberAttribute = changeLogLastChangeNumberAttribute;
     }
-    
+
     @ConfigurationProperty(order = 48)
+    public Boolean getChangeLogChangeNumberAttributesOnRootDSE() {
+        return changeLogChangeNumberAttributesOnRootDSE;
+    }
+
+    @SuppressWarnings("unused")
+    public void setChangeLogChangeNumberAttributesOnRootDSE(Boolean changeLogChangeNumberAttributesOnRootDSE) {
+        this.changeLogChangeNumberAttributesOnRootDSE = changeLogChangeNumberAttributesOnRootDSE;
+    }
+    
+    @ConfigurationProperty(order = 49)
     public String getChangeLogTargetUniqueIdAttribute() {
     	return changeLogTargetUniqueIdAttribute;
     }
@@ -1112,7 +1129,7 @@ public abstract class AbstractLdapConfiguration extends AbstractConfiguration {
     	this.changeLogTargetUniqueIdAttribute = changeLogTargetUniqueIdAttribute;
     }
     
-    @ConfigurationProperty(order = 49)
+    @ConfigurationProperty(order = 50)
     public String getChangeLogTargetEntryUUIDAttribute() {
     	return changeLogTargetEntryUUIDAttribute;
     }
@@ -1122,7 +1139,7 @@ public abstract class AbstractLdapConfiguration extends AbstractConfiguration {
     	this.changeLogTargetEntryUUIDAttribute = changeLogTargetEntryUUIDAttribute;
     }
     
-    @ConfigurationProperty(order = 50)
+    @ConfigurationProperty(order = 51)
     public String getChangeLogTargetDNAttribute() {
     	return changeLogTargetDNAttribute;
     }
@@ -1132,7 +1149,7 @@ public abstract class AbstractLdapConfiguration extends AbstractConfiguration {
     	this.changeLogTargetDNAttribute = changeLogTargetDNAttribute;
     }
     
-    @ConfigurationProperty(order = 51)
+    @ConfigurationProperty(order = 52)
     public boolean isUseUnsafeNameHint() {
         return useUnsafeNameHint;
     }
@@ -1142,7 +1159,7 @@ public abstract class AbstractLdapConfiguration extends AbstractConfiguration {
         this.useUnsafeNameHint = useUnsafeNameHint;
     }
 
-    @ConfigurationProperty(order = 52, allowedValues = { TEST_MODE_FULL, TEST_MODE_ANY, TEST_MODE_PRIMARY })
+    @ConfigurationProperty(order = 53, allowedValues = { TEST_MODE_FULL, TEST_MODE_ANY, TEST_MODE_PRIMARY })
     public String getTestMode() {
         return testMode;
     }
@@ -1152,7 +1169,7 @@ public abstract class AbstractLdapConfiguration extends AbstractConfiguration {
         this.testMode = testMode;
     }
 
-    @ConfigurationProperty(order = 53)
+    @ConfigurationProperty(order = 54)
     public boolean isEnableExtraTests() {
         return enableExtraTests;
     }
@@ -1162,7 +1179,7 @@ public abstract class AbstractLdapConfiguration extends AbstractConfiguration {
         this.enableExtraTests = enableExtraTests;
     }
 
-    @ConfigurationProperty(order = 54, allowedValues = { TIMESTAMP_PRESENTATION_NATIVE, TIMESTAMP_PRESENTATION_STRING, TIMESTAMP_PRESENTATION_UNIX_EPOCH })
+    @ConfigurationProperty(order = 55, allowedValues = { TIMESTAMP_PRESENTATION_NATIVE, TIMESTAMP_PRESENTATION_STRING, TIMESTAMP_PRESENTATION_UNIX_EPOCH })
     public String getTimestampPresentation() {
         return timestampPresentation;
     }
@@ -1172,7 +1189,7 @@ public abstract class AbstractLdapConfiguration extends AbstractConfiguration {
         this.timestampPresentation = timestampPresentation;
     }
 
-    @ConfigurationProperty(order = 55)
+    @ConfigurationProperty(order = 56)
     public boolean isIncludeObjectClassFilter() {
         return includeObjectClassFilter;
     }
@@ -1182,7 +1199,7 @@ public abstract class AbstractLdapConfiguration extends AbstractConfiguration {
         this.includeObjectClassFilter = includeObjectClassFilter;
     }
 
-    @ConfigurationProperty(order = 56)
+    @ConfigurationProperty(order = 57)
     public boolean isAlternativeObjectClassDetection() {
         return alternativeObjectClassDetection;
     }
@@ -1192,7 +1209,7 @@ public abstract class AbstractLdapConfiguration extends AbstractConfiguration {
         this.alternativeObjectClassDetection = alternativeObjectClassDetection;
     }
 
-    @ConfigurationProperty(order = 57)
+    @ConfigurationProperty(order = 58)
     public boolean isStructuralObjectClassesToAuxiliary() {
         return structuralObjectClassesToAuxiliary;
     }
@@ -1202,7 +1219,7 @@ public abstract class AbstractLdapConfiguration extends AbstractConfiguration {
         this.structuralObjectClassesToAuxiliary = structuralObjectClassesToAuxiliary;
     }
 
-    @ConfigurationProperty(order = 58, allowedValues = { RUN_AS_STRATEGY_NONE, RUN_AS_STRATEGY_BIND })
+    @ConfigurationProperty(order = 59, allowedValues = { RUN_AS_STRATEGY_NONE, RUN_AS_STRATEGY_BIND })
     public String getRunAsStrategy() {
         return runAsStrategy;
     }
@@ -1212,7 +1229,7 @@ public abstract class AbstractLdapConfiguration extends AbstractConfiguration {
         this.runAsStrategy = runAsStrategy;
     }
 
-    @ConfigurationProperty(order = 59)
+    @ConfigurationProperty(order = 60)
     public String getAdditionalSearchFilter() {
         return additionalSearchFilter;
     }
@@ -1222,7 +1239,7 @@ public abstract class AbstractLdapConfiguration extends AbstractConfiguration {
         this.additionalSearchFilter = additionalSearchFilter;
     }
 
-    @ConfigurationProperty(order = 60, allowedValues = { SEARCH_SCOPE_SUB, SEARCH_SCOPE_ONE })
+    @ConfigurationProperty(order = 61, allowedValues = { SEARCH_SCOPE_SUB, SEARCH_SCOPE_ONE })
     public String getDefaultSearchScope() {
         return defaultSearchScope;
     }
@@ -1232,7 +1249,7 @@ public abstract class AbstractLdapConfiguration extends AbstractConfiguration {
         this.defaultSearchScope = searchScope;
     }
 
-    @ConfigurationProperty(order = 61)
+    @ConfigurationProperty(order = 62)
     public boolean isAllowUntrustedSsl() {
         return allowUntrustedSsl;
     }
@@ -1242,7 +1259,7 @@ public abstract class AbstractLdapConfiguration extends AbstractConfiguration {
         this.allowUntrustedSsl = allowUntrustedSsl;
     }
 
-    @ConfigurationProperty(order = 62)
+    @ConfigurationProperty(order = 63)
     public boolean isUseUnbind() {
         return useUnbind;
     }
@@ -1252,7 +1269,7 @@ public abstract class AbstractLdapConfiguration extends AbstractConfiguration {
         this.useUnbind = useUnbind;
     }
 
-    @ConfigurationProperty(order = 63)
+    @ConfigurationProperty(order = 64)
     public long getSwitchBackInterval() {
         return switchBackInterval;
     }
@@ -1262,7 +1279,7 @@ public abstract class AbstractLdapConfiguration extends AbstractConfiguration {
         this.switchBackInterval = switchBackInterval;
     }
 
-    @ConfigurationProperty(order = 64)
+    @ConfigurationProperty(order = 65)
     public boolean isFilterOutMemberOfValues() {
         return filterOutMemberOfValues;
     }
@@ -1272,7 +1289,7 @@ public abstract class AbstractLdapConfiguration extends AbstractConfiguration {
         this.filterOutMemberOfValues = filterOutMemberOfValues;
     }
 
-    @ConfigurationProperty(order = 65)
+    @ConfigurationProperty(order = 66)
     public String[] getMemberOfAllowedValues() {
         return memberOfAllowedValues;
     }
@@ -1282,7 +1299,7 @@ public abstract class AbstractLdapConfiguration extends AbstractConfiguration {
         this.memberOfAllowedValues = memberOfAllowedValues;
     }
 
-    @ConfigurationProperty(order = 66)
+    @ConfigurationProperty(order = 67)
     public String[] getForceTreeDeleteObjectClasses() {
         return forceTreeDeleteObjectClasses;
     }
@@ -1293,7 +1310,7 @@ public abstract class AbstractLdapConfiguration extends AbstractConfiguration {
 
     }
 
-    @ConfigurationProperty(order = 67)
+    @ConfigurationProperty(order = 68)
 
     public String[] getGroupObjectClasses() {
         return groupObjectClasses;
@@ -1303,7 +1320,7 @@ public abstract class AbstractLdapConfiguration extends AbstractConfiguration {
         this.groupObjectClasses = groupObjectClasses;
     }
 
-    @ConfigurationProperty(order = 68)
+    @ConfigurationProperty(order = 69)
     public String[] getManagedAssociationPairs() {
         return managedAssociationPairs;
     }
@@ -1312,7 +1329,7 @@ public abstract class AbstractLdapConfiguration extends AbstractConfiguration {
         this.managedAssociationPairs = managedAssociationPairs;
     }
 
-    @ConfigurationProperty(order = 69)
+    @ConfigurationProperty(order = 70)
     public boolean getEncodeStringOnNormalizationFailure() {
         return encodeStringOnNormalizationFailure;
     }
@@ -1321,7 +1338,7 @@ public abstract class AbstractLdapConfiguration extends AbstractConfiguration {
         this.encodeStringOnNormalizationFailure = encodeStringOnNormalizationFailure;
     }
 
-    @ConfigurationProperty(order = 70)
+    @ConfigurationProperty(order = 71)
     public String[] getAttributesNotReturnedByDefault() {
         return attributesNotReturnedByDefault;
     }
@@ -1330,7 +1347,7 @@ public abstract class AbstractLdapConfiguration extends AbstractConfiguration {
         this.attributesNotReturnedByDefault = attributesNotReturnedByDefault;
     }
 
-    @ConfigurationProperty(order = 71)
+    @ConfigurationProperty(order = 72)
     public String[] getAuxiliaryObjectClasses() {
         return auxiliaryObjectClasses;
     }
@@ -1339,7 +1356,7 @@ public abstract class AbstractLdapConfiguration extends AbstractConfiguration {
         this.auxiliaryObjectClasses = auxiliaryObjectClasses;
     }
 
-    @ConfigurationProperty(order = 72)
+    @ConfigurationProperty(order = 73)
     public String getLastLoginDateAttribute() {
         return lastLoginDateAttribute;
     }
@@ -1348,7 +1365,7 @@ public abstract class AbstractLdapConfiguration extends AbstractConfiguration {
         this.lastLoginDateAttribute = lastLoginDateAttribute;
     }
 
-    @ConfigurationProperty(order = 73)
+    @ConfigurationProperty(order = 74)
     public boolean isLogSchemaErrors() {
         return logSchemaErrors;
     }

--- a/src/main/java/com/evolveum/polygon/connector/ldap/sync/AdDirSyncStrategy.java
+++ b/src/main/java/com/evolveum/polygon/connector/ldap/sync/AdDirSyncStrategy.java
@@ -29,6 +29,7 @@ import org.apache.directory.api.ldap.model.cursor.CursorException;
 import org.apache.directory.api.ldap.model.cursor.SearchCursor;
 import org.apache.directory.api.ldap.model.entry.Entry;
 import org.apache.directory.api.ldap.model.exception.LdapException;
+import org.apache.directory.api.ldap.model.exception.LdapInvalidDnException;
 import org.apache.directory.api.ldap.model.message.*;
 import org.apache.directory.api.ldap.model.name.Dn;
 import org.apache.directory.api.ldap.model.schema.SchemaManager;

--- a/src/main/java/com/evolveum/polygon/connector/ldap/sync/GenericChangeLogSyncStrategy.java
+++ b/src/main/java/com/evolveum/polygon/connector/ldap/sync/GenericChangeLogSyncStrategy.java
@@ -216,16 +216,12 @@ public class GenericChangeLogSyncStrategy<C extends AbstractLdapConfiguration> e
                 }
 
                 // TODO: filter out by modifiersName
-
-                SyncDeltaBuilder deltaBuilder = new SyncDeltaBuilder();
-
-                deltaBuilder.setToken(deltaToken);
-
                 String targetDn = LdapUtil.getStringAttribute(entry, targetEntryDNAttributeName);
                 switch (syncSearchScope) {
                     case ONELEVEL:
                         if (!(new Dn(targetDn)).getParent().equals(syncBaseContext)) {
                             LOG.ok("Changelog entry {0} refers to an entry {1} that is not a direct child of the base synchronisation context {2}, ignoring", entry.getDn(), targetDn, determineSyncBaseContext());
+                            continue;
                         }
                         break;
                     case SUBTREE:
@@ -239,6 +235,9 @@ public class GenericChangeLogSyncStrategy<C extends AbstractLdapConfiguration> e
                         throw new IllegalArgumentException("Invalid base context to use for syncing.");
                 }
 
+                SyncDeltaBuilder deltaBuilder = new SyncDeltaBuilder();
+
+                deltaBuilder.setToken(deltaToken);
 
                 String targetEntryUuid = LdapUtil.getStringAttribute(entry, targetEntryUUIDAttributeName);
                 String targetUniqueId = LdapUtil.getStringAttribute(entry, targetUniqueIdAttributeName);

--- a/src/main/java/com/evolveum/polygon/connector/ldap/sync/GenericChangeLogSyncStrategy.java
+++ b/src/main/java/com/evolveum/polygon/connector/ldap/sync/GenericChangeLogSyncStrategy.java
@@ -232,7 +232,7 @@ public class GenericChangeLogSyncStrategy<C extends AbstractLdapConfiguration> e
                         break;
                     default:
                         // We should not get to this point; AbstractLdapConfiguration only allows values of onelevel and subtree for the default search scope
-                        throw new IllegalArgumentException("Invalid base context to use for syncing.");
+                        throw new IllegalArgumentException("Invalid search scope to use for syncing.");
                 }
 
                 SyncDeltaBuilder deltaBuilder = new SyncDeltaBuilder();

--- a/src/main/resources/com/evolveum/polygon/connector/ldap/Messages.properties
+++ b/src/main/resources/com/evolveum/polygon/connector/ldap/Messages.properties
@@ -145,6 +145,27 @@ changeLogBlockSize.help=Number of change log entries to fetch in a single reques
 changeNumberAttribute.display=Change number attribute
 changeNumberAttribute.help="Change number" attribute - unique indentifier of the change in the change log.
 
+changeLogRootDSEAttribute.display=Changelog root DSE attribute
+changeLogRootDSEAttribute.help=Attribute name on the root DSE containing the DN of the top-levle changelog entry
+
+changeLogDN.display=Changelog DN
+changeLogDN.help=DN containing the LDAP changelog
+
+changeLogFirstChangeNumberAttribute.display=Changelog "first change number" attribute
+changeLogFirstChangeNumberAttribute.help="First change number" attribute - the name of the attribute on the top-level changelog entry containing the lowest change number of an entry within the changelog
+
+changeLogLastChangeNumberAttribute.display=Changelog "last change number" attribute
+changeLogLastChangeNumberAttribute.help="Last change number" attribute - the name of the attribute on the top-level changelog entry containing the highest change number of an entry within the changelog
+
+changeLogTargetUniqueIdAttribute.display=Changelog "target unique id" attribute
+changeLogTargetUniqueIdAttribute.help="Target unique id" attribute - the name of the attribute on a changelog entry containing the unique id of the modified object
+
+changeLogTargetEntryUUIDAttribute.display=Changelog "target entry UUID" attribute
+changeLogTargetEntryUUIDAttribute.help="Target entry UUID" attribute - the name of the attribute on a changelog entry containing the entryUUID of the modified object
+
+changeLogTargetDNAttribute.display=Changelog "target DN" attribute
+changeLogTargetDNAttribtue.help="Target DN" attribute - the name of the attribute on a changelog entry containing the DN of the modified object 
+
 useUnsafeNameHint.display=Use unsafe name hint
 useUnsafeNameHint.help=Entry DN can be provided to the connector as a "name hint". Connector will use the name hint whenever it can use it safely. But there are some cases when the name hint cannot be used safely. There are mostly modify and delete operations when in a rare case a wrong object can be modified or deleted. The connector will not use the name hint in these cases by default. It will make explicit search to make sure that everything is fair and square before attempting the operation. However this comes at the expense of performance. If this switch is set to true then the connector will try to use the name hint even if it is not completely safe. This may mean significant perfomacne boost for modify and delete operations.
 

--- a/src/main/resources/com/evolveum/polygon/connector/ldap/Messages.properties
+++ b/src/main/resources/com/evolveum/polygon/connector/ldap/Messages.properties
@@ -140,31 +140,34 @@ modifiersNamesToFilterOut.display=Modifiers names to filter out
 modifiersNamesToFilterOut.help=List of modifiers DNs that will NOT be accepted during synchronization.
 
 changeLogBlockSize.display=Changelog block size
-changeLogBlockSize.help=Number of change log entries to fetch in a single request.
+changeLogBlockSize.help=Number of change log entries to fetch in a single request. Default value: 100
 
 changeNumberAttribute.display=Change number attribute
-changeNumberAttribute.help="Change number" attribute - unique indentifier of the change in the change log.
+changeNumberAttribute.help="Change number" attribute - unique indentifier of the change in the change log. Default value: changeNumber
 
 changeLogRootDSEAttribute.display=Changelog root DSE attribute
-changeLogRootDSEAttribute.help=Attribute name on the root DSE containing the DN of the top-levle changelog entry
+changeLogRootDSEAttribute.help=Attribute name on the root DSE containing the DN of the top-level changelog entry. Default value: changelog
 
 changeLogDN.display=Changelog DN
-changeLogDN.help=DN containing the LDAP changelog
+changeLogDN.help=DN containing the LDAP changelog. Default value: cn=changelog
 
 changeLogFirstChangeNumberAttribute.display=Changelog "first change number" attribute
-changeLogFirstChangeNumberAttribute.help="First change number" attribute - the name of the attribute on the top-level changelog entry containing the lowest change number of an entry within the changelog
+changeLogFirstChangeNumberAttribute.help="First change number" attribute - the name of the attribute containing the lowest change number of an entry within the changelog. Default value: firstChangeNumber
 
 changeLogLastChangeNumberAttribute.display=Changelog "last change number" attribute
-changeLogLastChangeNumberAttribute.help="Last change number" attribute - the name of the attribute on the top-level changelog entry containing the highest change number of an entry within the changelog
+changeLogLastChangeNumberAttribute.help="Last change number" attribute - the name of the attribute containing the highest change number of an entry within the changelog. Default value: lastChangeNumber
+
+changeLogChangeNumberAttributesOnRootDSE.display=Read changelog change number attributes from root DSE
+changeLogChangeNumberAttributesOnRootDSE.help=Should the changelog change number attributes be read from the root DSE, or the top-level changelog entry as configured. Default value: true
 
 changeLogTargetUniqueIdAttribute.display=Changelog "target unique id" attribute
-changeLogTargetUniqueIdAttribute.help="Target unique id" attribute - the name of the attribute on a changelog entry containing the unique id of the modified object
+changeLogTargetUniqueIdAttribute.help="Target unique id" attribute - the name of the attribute on a changelog entry containing the unique id of the modified object. Default value: targetUniqueID
 
 changeLogTargetEntryUUIDAttribute.display=Changelog "target entry UUID" attribute
-changeLogTargetEntryUUIDAttribute.help="Target entry UUID" attribute - the name of the attribute on a changelog entry containing the entryUUID of the modified object
+changeLogTargetEntryUUIDAttribute.help="Target entry UUID" attribute - the name of the attribute on a changelog entry containing the entryUUID of the modified object. Default value: targetEntryUUID
 
 changeLogTargetDNAttribute.display=Changelog "target DN" attribute
-changeLogTargetDNAttribtue.help="Target DN" attribute - the name of the attribute on a changelog entry containing the DN of the modified object 
+changeLogTargetDNAttribtue.help="Target DN" attribute - the name of the attribute on a changelog entry containing the DN of the modified object. Default value: targetDN
 
 useUnsafeNameHint.display=Use unsafe name hint
 useUnsafeNameHint.help=Entry DN can be provided to the connector as a "name hint". Connector will use the name hint whenever it can use it safely. But there are some cases when the name hint cannot be used safely. There are mostly modify and delete operations when in a rare case a wrong object can be modified or deleted. The connector will not use the name hint in these cases by default. It will make explicit search to make sure that everything is fair and square before attempting the operation. However this comes at the expense of performance. If this switch is set to true then the connector will try to use the name hint even if it is not completely safe. This may mean significant perfomacne boost for modify and delete operations.

--- a/src/main/resources/com/evolveum/polygon/connector/ldap/ad/Messages.properties
+++ b/src/main/resources/com/evolveum/polygon/connector/ldap/ad/Messages.properties
@@ -145,6 +145,27 @@ changeLogBlockSize.help=Number of change log entries to fetch in a single reques
 changeNumberAttribute.display=Change number attribute
 changeNumberAttribute.help="Change number" attribute - unique indentifier of the change in the change log.
 
+changeLogRootDSEAttribute.display=Changelog root DSE attribute
+changeLogRootDSEAttribute.help=Attribute name on the root DSE containing the DN of the top-levle changelog entry
+
+changeLogDN.display=Changelog DN
+changeLogDN.help=DN containing the LDAP changelog
+
+changeLogFirstChangeNumberAttribute.display=Changelog "first change number" attribute
+changeLogFirstChangeNumberAttribute.help="First change number" attribute - the name of the attribute on the top-level changelog entry containing the lowest change number of an entry within the changelog
+
+changeLogLastChangeNumberAttribute.display=Changelog "last change number" attribute
+changeLogLastChangeNumberAttribute.help="Last change number" attribute - the name of the attribute on the top-level changelog entry containing the highest change number of an entry within the changelog
+
+changeLogTargetUniqueIdAttribute.display=Changelog "target unique id" attribute
+changeLogTargetUniqueIdAttribute.help="Target unique id" attribute - the name of the attribute on a changelog entry containing the unique id of the modified object
+
+changeLogTargetEntryUUIDAttribute.display=Changelog "target entry UUID" attribute
+changeLogTargetEntryUUIDAttribute.help="Target entry UUID" attribute - the name of the attribute on a changelog entry containing the entryUUID of the modified object
+
+changeLogTargetDNAttribute.display=Changelog "target DN" attribute
+changeLogTargetDNAttribtue.help="Target DN" attribute - the name of the attribute on a changelog entry containing the DN of the modified object 
+
 useUnsafeNameHint.display=Use unsafe name hint
 useUnsafeNameHint.help=Entry DN can be provided to the connector as a "name hint". Connector will use the name hint whenever it can use it safely. But there are some cases when the name hint cannot be used safely. There are mostly modify and delete operations when in a rare case a wrong object can be modified or deleted. The connector will not use the name hint in these cases by default. It will make explicit search to make sure that everything is fair and square before attempting the operation. However this comes at the expense of performance. If this switch is set to true then the connector will try to use the name hint even if it is not completely safe. This may mean significant perfomacne boost for modify and delete operations.
 


### PR DESCRIPTION
As part of this commit, the configuration and SunChangelogSyncStrategy have been extended to be more configurable; primarily with the ability to change the attribute names used by the sync strategy. 
This allows for other directory software that uses a similiar approach to change logs as SunDS, such as Isode M-Vault, to also work with this sync strategy implementation. 
Although the class has been renamed as part of this commit to reflect the more generic nature of the modified class, the default configuration options, and SyncStrategy option of "sunChangeLog" have been retained for backwards-compatibility.