### PR TITLE
Fix schema tweaking for objectClasses extending user

### DIFF
--- a/src/main/java/com/evolveum/polygon/connector/ldap/LdapSchemaTranslator.java
+++ b/src/main/java/com/evolveum/polygon/connector/ldap/LdapSchemaTranslator.java
@@ -29,6 +29,7 @@ import org.apache.directory.api.ldap.model.entry.Entry;
 import org.apache.directory.api.ldap.model.entry.Value;
 import org.apache.directory.api.ldap.model.schema.AttributeType;
 import org.apache.directory.api.ldap.model.schema.LdapSyntax;
+import org.apache.directory.api.ldap.model.schema.ObjectClass;
 import org.apache.directory.api.ldap.model.schema.SchemaManager;
 import org.apache.directory.ldap.client.api.LdapNetworkConnection;
 import org.identityconnectors.common.logging.Log;
@@ -261,8 +262,8 @@ public class LdapSchemaTranslator extends AbstractSchemaTranslator<LdapConfigura
     }
 
     @Override
-    protected void extendConnectorObject(ConnectorObjectBuilder cob, Entry entry, String objectClassName) {
-        super.extendConnectorObject(cob, entry, objectClassName);
+    protected void extendConnectorObject(ConnectorObjectBuilder cob, Entry entry, ObjectClass ldapObjectClass) {
+        super.extendConnectorObject(cob, entry, ldapObjectClass);
 
         if (getConfiguration().isOpenLdapLockoutStrategy()) {
             String pwdAccountLockedTime = LdapUtil.getStringAttribute(entry, SchemaConstants.PWD_ACCOUNT_LOCKED_TIME_AT);

--- a/src/main/java/com/evolveum/polygon/connector/ldap/ad/AdLdapConnector.java
+++ b/src/main/java/com/evolveum/polygon/connector/ldap/ad/AdLdapConnector.java
@@ -184,7 +184,7 @@ public class AdLdapConnector extends AbstractLdapConnector<AdLdapConfiguration> 
             org.apache.directory.api.ldap.model.schema.ObjectClass ldapStructuralObjectClass,
             Set<Attribute> createAttributes) {
         if ((getConfiguration().isRawUserParametersAttribute() && getConfiguration().isRawUserAccountControlAttribute())
-                || !getSchemaTranslator().isUserObjectClass(ldapStructuralObjectClass.getName())) {
+                || !getSchemaTranslator().isUserObjectClass(ldapStructuralObjectClass)) {
             return super.prepareCreateConnIdAttributes(connIdObjectClass, ldapStructuralObjectClass, createAttributes);
         }
 
@@ -345,7 +345,7 @@ public class AdLdapConnector extends AbstractLdapConnector<AdLdapConfiguration> 
     public Set<AttributeDelta> updateDelta(org.identityconnectors.framework.common.objects.ObjectClass connIdObjectClass, Uid uid, Set<AttributeDelta> deltas,
             OperationOptions options) {
         org.apache.directory.api.ldap.model.schema.ObjectClass ldapObjectClass = getSchemaTranslator().toLdapObjectClass(connIdObjectClass);
-        boolean isUserObjectClass = getSchemaTranslator().isUserObjectClass(ldapObjectClass.getName());
+        boolean isUserObjectClass = getSchemaTranslator().isUserObjectClass(ldapObjectClass);
 
         boolean hasUacPatch = !getConfiguration().isRawUserAccountControlAttribute() && isUserObjectClass && hasUacDelta(deltas);
         boolean hasUpPatch = !getConfiguration().isRawUserParametersAttribute() && isUserObjectClass && hasUpDelta(deltas);
@@ -844,7 +844,7 @@ public class AdLdapConnector extends AbstractLdapConnector<AdLdapConfiguration> 
 
     private boolean isUserPasswordChanged(Set<AttributeDelta> deltas, org.apache.directory.api.ldap.model.schema.ObjectClass ldapStructuralObjectClass) {
         //if password is in modifications set pwdLastSet=0 ("must change password at next logon")
-        if (getSchemaTranslator().isUserObjectClass(ldapStructuralObjectClass.getName())) {
+        if (getSchemaTranslator().isUserObjectClass(ldapStructuralObjectClass)) {
             for (AttributeDelta delta: deltas) {
                 // coming from midpoint password is __PASSWORD__
                 // TODO: should we additionally ask for  icfAttr.getName().equals(getConfiguration().getPasswordAttribute()?

--- a/src/main/java/com/evolveum/polygon/connector/ldap/schema/AbstractSchemaTranslator.java
+++ b/src/main/java/com/evolveum/polygon/connector/ldap/schema/AbstractSchemaTranslator.java
@@ -1509,7 +1509,7 @@ public abstract class AbstractSchemaTranslator<C extends AbstractLdapConfigurati
 
         }
 
-        extendConnectorObject(cob, entry, connIdStructuralObjectClassInfo.getType());
+        extendConnectorObject(cob, entry, ldapObjectClasses.getLdapLowestStructuralObjectClass());
         
         return cob.build();
     }
@@ -1872,7 +1872,7 @@ public abstract class AbstractSchemaTranslator<C extends AbstractLdapConfigurati
         return true;
     }
 
-    protected void extendConnectorObject(ConnectorObjectBuilder cob, Entry entry, String objectClassName) {
+    protected void extendConnectorObject(ConnectorObjectBuilder cob, Entry entry, org.apache.directory.api.ldap.model.schema.ObjectClass ldapObjectClass) {
         // Nothing to do here. This is supposed to be overriden by subclasses.
     }
 


### PR DESCRIPTION
### Problem
When using a LDAP objectClass that extends the AD `user` objectClass (e.g. the `msDS-GroupManagedServiceAccount` from Microsoft AD), the connector's schema tweaking logic failed to recognize it as a user-type class. This meant that critical attributes like `sAMAccountName` and `objectSid` — which are not declared in the AD LDAP schema but are injected by the connector via `tweakSchema` — were not added to the ConnId schema for the custom objectClass. As a result, midPoint could not discover or use `sAMAccountName` for accounts of the custom type.

### Root Cause
The `isUserObjectClass` method in `AdSchemaTranslator` previously performed only a direct name comparison against the configured `userObjectClass`. It did not consider the LDAP objectClass inheritance hierarchy, so a custom class like `myUser SUP user` would not be recognized as a user class.

### Fix
`isUserObjectClass` now recursively walks the LDAP objectClass superiors chain via `getSuperiors()`. If any ancestor matches the configured user objectClass, the class is correctly identified as a user type. This ensures that `extendObjectClassDefinition` adds `sAMAccountName`, `objectSid`, UAC attributes, and `userParameters` attributes to any objectClass that inherits from `user`, not just the `user` class itself.

### Impact
- Custom objectClasses extending `user` now correctly receive `sAMAccountName` and `objectSid` in their ConnId schema
- UAC-based enable/disable and `userParameters` handling also applies to these derived classes
- No change in behavior for standard `user` or `group` objectClasses