### PR TITLE
Fix object class type identification for Active Directory

### DIFF
--- a/src/main/java/com/evolveum/polygon/connector/ldap/ad/AdConstants.java
+++ b/src/main/java/com/evolveum/polygon/connector/ldap/ad/AdConstants.java
@@ -57,6 +57,7 @@ public class AdConstants {
     public static final String ATTRIBUTE_SUB_CLASS_OF_NAME = "subClassOf";
     public static final String ATTRIBUTE_AUXILIARY_CLASS_NAME = "auxiliaryClass";
     public static final String ATTRIBUTE_DEFAULT_OBJECT_CATEGORY_NAME = "defaultObjectCategory";
+    public static final String ATTRIBUTE_OBJECT_CLASS_CATEGORY_NAME = "objectClassCategory";
 
 
     public static final String ATTRIBUTE_MS_DS_MEMBER_TRANSITIVE= "msds-memberTransitive";

--- a/src/main/java/com/evolveum/polygon/connector/ldap/ad/AdSchemaLoader.java
+++ b/src/main/java/com/evolveum/polygon/connector/ldap/ad/AdSchemaLoader.java
@@ -44,6 +44,7 @@ import org.apache.directory.api.ldap.model.message.controls.PagedResults;
 import org.apache.directory.api.ldap.model.message.controls.PagedResultsImpl;
 import org.apache.directory.api.ldap.model.name.Dn;
 import org.apache.directory.api.ldap.model.schema.LdapSyntax;
+import org.apache.directory.api.ldap.model.schema.ObjectClassTypeEnum;
 import org.apache.directory.ldap.client.api.DefaultSchemaLoader;
 import org.apache.directory.ldap.client.api.LdapConnection;
 import org.apache.directory.ldap.client.api.exception.InvalidConnectionException;
@@ -287,6 +288,22 @@ public class AdSchemaLoader extends DefaultSchemaLoader {
                 // Name of this method says "oid" but what it really mean is "name"
                 objectClass.setSuperiorOids(Arrays.asList(superClassName));
             }
+        }
+
+        Integer objectClassCategory = LdapUtil.getIntegerAttribute(schemaEntry, AdConstants.ATTRIBUTE_OBJECT_CLASS_CATEGORY_NAME, -1);
+        switch (objectClassCategory) {
+            case 0: // 88 object class, which the Apache API doesn't accommodate
+            case 1:
+                objectClass.setType(ObjectClassTypeEnum.STRUCTURAL);
+                break;
+            case 2:
+                objectClass.setType(ObjectClassTypeEnum.ABSTRACT);
+                break;
+            case 3:
+                objectClass.setType(ObjectClassTypeEnum.AUXILIARY);
+                break;
+            default:
+                throw new LdapSchemaException("Class "+className+" has invalid/missing value for "+AdConstants.ATTRIBUTE_OBJECT_CLASS_CATEGORY_NAME+" attribute");
         }
 
         List<String> mustAttributeNames = new ArrayList();


### PR DESCRIPTION
### Problem
Object classes from the AD schema are incorrectly categorized as structural. This causes issues in downstream logic (e.g. AbstractSchemaTranslator has multiple checks for auxiliary object classes).

Active Directory uses the objectClassCategory attribute to identify object class types (structural, auxiliary, etc.) in the schema. The Apache Directory LDAP API only checks the m-typeObjectClass attribute since that is what ApacheDS uses (see the getObjectClass method in org.apache.directory.api.ldap.schema.loader.SchemaEntityFactory).

### Fix
Logic has been added to properly categorize object classes in AdSchemaLoader.

This change removes the need for the operationalAttributes workaround mentioned in [MID-3379](https://support.evolveum.com/wp/3379).

### References

- [https://learn.microsoft.com/en-us/windows/win32/adschema/a-objectclasscategory](https://learn.microsoft.com/en-us/windows/win32/adschema/a-objectclasscategory)
- [https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-adts/85397795-f089-4807-89be-24822570bc2c](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-adts/85397795-f089-4807-89be-24822570bc2c)