### PR TITLE
Add object class descriptions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>connector-parent</artifactId>
         <groupId>com.evolveum.polygon</groupId>
-        <version>1.5.3.0-M3</version>
+        <version>1.5.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>connector-ldap</artifactId>

--- a/src/main/java/com/evolveum/polygon/connector/ldap/ad/AdConstants.java
+++ b/src/main/java/com/evolveum/polygon/connector/ldap/ad/AdConstants.java
@@ -45,6 +45,8 @@ public class AdConstants {
     public static final String ATTRIBUTE_GOVERNS_ID_NAME = "governsID";
     public static final String ATTRIBUTE_ATTRIBUTE_ID_NAME = "attributeID";
     public static final String ATTRIBUTE_LDAP_DISPLAY_NAME_NAME = "lDAPDisplayName";
+    public static final String ATTRIBUTE_ADMIN_DESCRIPTION_NAME = "adminDescription";
+    public static final String ATTRIBUTE_DESCRIPTION_NAME = "description";
     public static final String ATTRIBUTE_IS_SINGLE_VALUED_NAME = "isSingleValued";
     public static final String ATTRIBUTE_ATTRIBUTE_SYNTAX_NAME = "attributeSyntax";
     public static final String ATTRIBUTE_MUST_CONTAIN_NAME = "mustContain";

--- a/src/main/java/com/evolveum/polygon/connector/ldap/ad/AdSchemaLoader.java
+++ b/src/main/java/com/evolveum/polygon/connector/ldap/ad/AdSchemaLoader.java
@@ -273,8 +273,7 @@ public class AdSchemaLoader extends DefaultSchemaLoader {
         String oid = LdapUtil.getStringAttribute(schemaEntry, AdConstants.ATTRIBUTE_GOVERNS_ID_NAME);
         AdObjectClass objectClass = new AdObjectClass(oid);
         objectClass.setNames(className);
-        // TODO
-        objectClass.setDescription(LdapUtil.getStringAttribute(schemaEntry, SchemaConstants.CN_AT));
+        objectClass.setDescription(determineObjectClassDescription(schemaEntry));
         objectClass.setEnabled(true);
 
         if (!className.equals(SchemaConstants.TOP_OC)) {
@@ -306,6 +305,15 @@ public class AdSchemaLoader extends DefaultSchemaLoader {
         objectClass.setSchemaName(AdConstants.AD_SCHEMA_NAME);
 //        LOG.ok("Registering object class {0} ({1}):\n{2}", className, oid, objectClass);
         updateSchemas(objectClass);
+    }
+
+    static String determineObjectClassDescription(Entry schemaEntry) {
+        String adminDescription = LdapUtil.getStringAttribute(
+                schemaEntry, AdConstants.ATTRIBUTE_ADMIN_DESCRIPTION_NAME);
+        if (adminDescription != null && !adminDescription.isBlank()) {
+            return adminDescription;
+        }
+        return LdapUtil.getStringAttribute(schemaEntry, AdConstants.ATTRIBUTE_DESCRIPTION_NAME);
     }
 
     private void addToAttributesList(List<String> attributeNames, Entry schemaEntry, String attributeName) throws LdapSchemaException {

--- a/src/main/java/com/evolveum/polygon/connector/ldap/schema/AbstractSchemaTranslator.java
+++ b/src/main/java/com/evolveum/polygon/connector/ldap/schema/AbstractSchemaTranslator.java
@@ -111,6 +111,7 @@ public abstract class AbstractSchemaTranslator<C extends AbstractLdapConfigurati
                 LOG.ok("Found LDAP schema object class {0}, translating", ldapObjectClass.getName());
                 ObjectClassInfoBuilder ocib = new ObjectClassInfoBuilder();
                 ocib.setType(toIcfObjectClassType(ldapObjectClass));
+                ocib.setDescription(ldapObjectClass.getDescription());
                 Map<String, AttributeInfo> attrInfoList = new HashMap<>();
                 addAttributeTypes(attrInfoList, ldapObjectClass);
                 ocib.addAllAttributeInfo(attrInfoList.values());

--- a/src/test/java/com/evolveum/polygon/connector/ldap/TestOpenDj.java
+++ b/src/test/java/com/evolveum/polygon/connector/ldap/TestOpenDj.java
@@ -104,7 +104,13 @@ public class TestOpenDj extends AbstractOpenDjTest {
     public void testOpSchema() throws Exception {
         ConnectorFacade connector = createConnectorInstance();
         Schema schema = connector.schema();
-        // TODO: asserts
+        ObjectClassInfo posixAccount = schema.getObjectClassInfo().stream()
+                .filter(objectClassInfo -> "posixAccount".equalsIgnoreCase(objectClassInfo.getType()))
+                .findFirst()
+                .orElse(null);
+        assertNotNull("posixAccount object class is missing from the schema", posixAccount);
+        assertEquals("Unexpected posixAccount description",
+                "Abstraction of an account with POSIX attributes", posixAccount.getDescription());
     }
 
     // Try partial configuration with a wrong password

--- a/src/test/java/com/evolveum/polygon/connector/ldap/ad/TestAdSchemaLoader.java
+++ b/src/test/java/com/evolveum/polygon/connector/ldap/ad/TestAdSchemaLoader.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2026 Evolveum
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.evolveum.polygon.connector.ldap.ad;
+
+import org.apache.directory.api.ldap.model.entry.DefaultEntry;
+import org.apache.directory.api.ldap.model.entry.Entry;
+import org.testng.annotations.Test;
+
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertNull;
+
+public class TestAdSchemaLoader {
+
+    @Test
+    public void testObjectClassDescriptionPrefersAdminDescription() throws Exception {
+        Entry schemaEntry = new DefaultEntry();
+        schemaEntry.add(AdConstants.ATTRIBUTE_ADMIN_DESCRIPTION_NAME, "Administrative description");
+        schemaEntry.add(AdConstants.ATTRIBUTE_DESCRIPTION_NAME, "General description");
+
+        assertEquals("Administrative description", AdSchemaLoader.determineObjectClassDescription(schemaEntry));
+    }
+
+    @Test
+    public void testObjectClassDescriptionFallsBackToDescription() throws Exception {
+        Entry schemaEntry = new DefaultEntry();
+        schemaEntry.add(AdConstants.ATTRIBUTE_DESCRIPTION_NAME, "General description");
+
+        assertEquals("General description", AdSchemaLoader.determineObjectClassDescription(schemaEntry));
+    }
+
+    @Test
+    public void testObjectClassDescriptionCanBeEmpty() {
+        assertNull(AdSchemaLoader.determineObjectClassDescription(new DefaultEntry()));
+    }
+}


### PR DESCRIPTION
## Summary

Expose directory-provided LDAP object class descriptions through the ConnId schema.

## Implementation

- Propagate LDAP object class descriptions into ObjectClassInfo.
- For Active Directory schema entries, prefer adminDescription and fall back to description.
- Update the connector parent to 1.5.3.0-SNAPSHOT for object class description support.

## Verification

- Added unit coverage for Active Directory description precedence, fallback, and missing values.
- Extended the OpenDJ schema test to verify the posixAccount description.

## Tracking

Story: https://support.evolveum.com/projects/connectors/work_packages/11625/activity

This is part of a coordinated change across the LDAP, Google Apps, Microsoft Graph API, SAP, and Zoom connectors.

## Related pull requests

- LDAP: https://github.com/Evolveum/connector-ldap/pull/43
- Google Apps: https://github.com/Evolveum/connector-googleapps/pull/20
- Microsoft Graph API: https://github.com/Evolveum/connector-microsoft-graph-api/pull/46
- SAP: https://github.com/Evolveum/connector-sap/pull/15
- Zoom: https://github.com/Evolveum/connector-zoom/pull/1

## Local testing

Built and deployed the branch connector into Docker midPoint 4.11 nightly against Docker OpenDJ. Resource connection and schema refresh succeeded, and 69 LDAP object class descriptions were persisted in the refreshed schema.